### PR TITLE
Bugfix: Fix git checkout and git push commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Add the following step at the end of your job.
     commit_author_email: john.doe@example.com
     commit_author_name: John Doe
     commit_message: Apply automatic changes
+    ref: ${{ github.head_ref }}
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -32,6 +33,7 @@ The following inputs are required
 - `commit_author_email`: The Commit Authors Email Address
 - `commit_author_name`: The Commit Authors Name
 - `commit_message`: The commit message used when changes are available
+- `ref`: Branch where changes should be pushed too
 
 ### Environment Variables
 

--- a/actions.yml
+++ b/actions.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Email address of the commit author'
     required: true
 
+  ref:
+    description: Branch to use
+    required: true
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/actions.yml
+++ b/actions.yml
@@ -5,17 +5,16 @@ author: Stefan Zweifel <hello@stefanzweifel.io>
 
 inputs:
   commit_message:
-    description: 'Commit message'
+    description: Commit message
     required: true
   commit_author_name:
-    description: 'Name of the commit author'
+    description: Name of the commit author
     required: true
   commit_author_email:
-    description: 'Email address of the commit author'
+    description: Email address of the commit author
     required: true
-
   ref:
-    description: Branch to use
+    description: Branch where changes should be pushed too
     required: true
 
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ then
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>"
 
-    git push --set-upstream origin "${GITHUB_REF:11}"
+    git push --set-upstream origin $PUSH_BRANCH
 else
     echo "Working tree clean. Nothing to commit."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,8 +25,10 @@ if ! git diff --quiet
 then
     git_setup
 
+    : ${PUSH_BRANCH:=`echo "$GITHUB_HEAD_REF" | awk -F / '{ print $3 }' `}
+
     # Switch to branch from current Workflow run
-    git checkout "$GITHUB_REF" | awk -F / '{ print $3 }'
+    git checkout $PUSH_BRANCH
 
     git add .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ then
     git_setup
 
     # Switch to branch from current Workflow run
-    git checkout "${GITHUB_REF:11}"
+    git checkout "$GITHUB_REF" | awk -F / '{ print $3 }'
 
     git add .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,11 +25,7 @@ if ! git diff --quiet
 then
     git_setup
 
-    : ${PUSH_BRANCH:=`echo "$GITHUB_HEAD_REF" | awk -F / '{ print $3 }' `}
-
-    echo "Push Branch Value: $PUSH_BRANCH";
-
-    echo "Input Ref: $INPUT_REF";
+    echo "INPUT_REF value: $INPUT_REF";
 
     # Switch to branch from current Workflow run
     git checkout $INPUT_REF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ then
     echo "Push Branch Value: $PUSH_BRANCH";
 
     # Switch to branch from current Workflow run
-    git checkout -b $INPUT_REF
+    git checkout $INPUT_REF
 
     git add .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,8 @@ then
 
     : ${PUSH_BRANCH:=`echo "$GITHUB_HEAD_REF" | awk -F / '{ print $3 }' `}
 
+    git switch -c $PUSH_BRANCH
+
     # Switch to branch from current Workflow run
     git checkout $PUSH_BRANCH
 
@@ -34,7 +36,7 @@ then
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>"
 
-    git push --set-upstream origin "HEAD:$PUSH_BRANCH"
+    git push --set-upstream origin $PUSH_BRANCH
 else
     echo "Working tree clean. Nothing to commit."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ then
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>"
 
-    git push --set-upstream origin HEAD:"$PUSH_BRANCH"
+    git push --set-upstream origin "HEAD:$PUSH_BRANCH"
 else
     echo "Working tree clean. Nothing to commit."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,10 +27,8 @@ then
 
     : ${PUSH_BRANCH:=`echo "$GITHUB_HEAD_REF" | awk -F / '{ print $3 }' `}
 
-    git switch -c $PUSH_BRANCH
-
     # Switch to branch from current Workflow run
-    git checkout $PUSH_BRANCH
+    git checkout -b $PUSH_BRANCH
 
     git add .
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ then
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>"
 
-    git push --set-upstream origin $INPUT_REF
+    git push --set-upstream origin "HEAD:$INPUT_REF"
 else
     echo "Working tree clean. Nothing to commit."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,8 @@ then
 
     echo "Push Branch Value: $PUSH_BRANCH";
 
+    echo "Input Ref: $INPUT_REF";
+
     # Switch to branch from current Workflow run
     git checkout $INPUT_REF
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,8 @@ then
 
     : ${PUSH_BRANCH:=`echo "$GITHUB_HEAD_REF" | awk -F / '{ print $3 }' `}
 
+    echo "Push Branch Value: $PUSH_BRANCH";
+
     # Switch to branch from current Workflow run
     git checkout -b $PUSH_BRANCH
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,13 +30,13 @@ then
     echo "Push Branch Value: $PUSH_BRANCH";
 
     # Switch to branch from current Workflow run
-    git checkout -b $PUSH_BRANCH
+    git checkout -b $INPUT_REF
 
     git add .
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>"
 
-    git push --set-upstream origin $PUSH_BRANCH
+    git push --set-upstream origin $INPUT_REF
 else
     echo "Working tree clean. Nothing to commit."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ then
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>"
 
-    git push --set-upstream origin $PUSH_BRANCH
+    git push --set-upstream origin HEAD:"$PUSH_BRANCH"
 else
     echo "Working tree clean. Nothing to commit."
 fi


### PR DESCRIPTION
The method to get the branch name via `${GITHUB_REF:11}` is broken.
I've decided to add a new `ref` argument to the Action.

This argument determines which branch should be used for pushing. This value doesn't have to be hardcoded though. We can use the GitHub context in our workflow files (`ref: ${{ github.head_ref }}`).

