### PR TITLE
Feature: Add File Pattern Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/stefanzweifel/git-auto-commit-action/compare/v2.1.0...HEAD)
+## [Unreleased](https://github.com/stefanzweifel/git-auto-commit-action/compare/v2.2.0...HEAD)
+
+## [v2.2.0](https://github.com/stefanzweifel/git-auto-commit-action/compare/v2.1.0...v2.2.0) - 2019-10-26
+
+### Added
+- Add new `file_pattern`-argument. Allows users to define which files should be added in the commit. [#13](https://github.com/stefanzweifel/git-auto-commit-action/pull/13)
 
 ## [v2.1.0](https://github.com/stefanzweifel/git-auto-commit-action/compare/v2.0.0...v2.1.0) - 2019-09-20
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Add the following step at the end of your job.
   with:
     commit_message: Apply automatic changes
     branch: ${{ github.head_ref }}
+
+    # Optional glob pattern of files which should be added to the commit
+    file_pattern: src/\*.js
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -26,18 +29,6 @@ You **do not** have to create a new secret called `GITHUB_TOKEN` in your reposit
 The Action will only commit files back, if changes are available. The resulting commit **will not trigger** another GitHub Actions Workflow run!
 
 It is recommended to use this Action in Workflows which listen to the `pull_request` event. If you want to use the Action on other events, you have to hardcode the value for `branch` as `github.head_ref` is only available in Pull Requests.
-
-
-### Inputs
-
-The following inputs are required
-
-- `commit_message`: The commit message used when changes are available
-- `branch`: Branch name where changes should be pushed to
-
-### Environment Variables
-
-The `GITHUB_TOKEN` secret is required. It is automatically available in your repository. You have to add it to the configuration though.
 
 ## Example Usage
 
@@ -72,10 +63,15 @@ jobs:
       with:
         commit_message: Apply php-cs-fixer changes
         branch: ${{ github.head_ref }}
+        file_pattern: src/\*.php
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 ```
+
+### Inputs
+
+Checkout [`actions.yml`](https://github.com/stefanzweifel/git-auto-commit-action/blob/master/actions.yml) for a full list of supported inputs.
 
 ## Versioning
 

--- a/actions.yml
+++ b/actions.yml
@@ -12,6 +12,7 @@ inputs:
     required: true
   file_pattern:
     description: File pattern used for "git add"
+    required: false
     default: '.'
 
 runs:

--- a/actions.yml
+++ b/actions.yml
@@ -10,6 +10,9 @@ inputs:
   branch:
     description: Branch where changes should be pushed too
     required: true
+  file_pattern:
+    description: File pattern used for "git add"
+    default: '.'
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,12 +30,14 @@ then
     # Switch to branch from current Workflow run
     git checkout $INPUT_BRANCH
 
-    if [ -z ${INPUT_FILE_PATTERN+x} ];
-    then
-        git add .
-    else
-        git add $INPUT_FILE_PATTERN
-    fi
+    # if [ -z ${INPUT_FILE_PATTERN+x} ];
+    # then
+    #     git add .
+    # else
+    #     git add $INPUT_FILE_PATTERN
+    # fi
+
+    git add $INPUT_FILE_PATTERN
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,12 @@ then
     # Switch to branch from current Workflow run
     git checkout $INPUT_BRANCH
 
-    git add $INPUT_FILE_PATTERN
+    if [ -z ${INPUT_FILE_PATTERN+x} ];
+    then
+        git add .
+    else
+        git add $INPUT_FILE_PATTERN
+    fi
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ then
     # Switch to branch from current Workflow run
     git checkout $INPUT_BRANCH
 
-    git add .
+    git add $INPUT_FILE_PATTERN
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,14 +30,13 @@ then
     # Switch to branch from current Workflow run
     git checkout $INPUT_BRANCH
 
-    # if [ -z ${INPUT_FILE_PATTERN+x} ];
-    # then
-    #     git add .
-    # else
-    #     git add $INPUT_FILE_PATTERN
-    # fi
-
-    git add $INPUT_FILE_PATTERN
+    if [ -z ${INPUT_FILE_PATTERN+x} ];
+    then
+        git add .
+    else
+        echo "INPUT_FILE_PATTERN value: $INPUT_FILE_PATTERN";
+        git add $INPUT_FILE_PATTERN
+    fi
 
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
 


### PR DESCRIPTION
Fixes #12 

Adds a new `file_pattern` input, which allows user to customize, which files should be added to the git commit.

### Example usage:

```
    - uses: stefanzweifel/git-auto-commit-action@v.x.x.x
      with:
        commit_message: Commit Message
        branch: ${{ github.head_ref }}
        file_pattern: src/\*.js
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


```