### PR TITLE
Fix: Use 'git status -s' to check for untracked/modified files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ EOF
 
 # This section only runs if there have been file changes
 echo "Checking for uncommitted changes in the git working tree."
-if ! git diff --quiet
+if [[ -n "$(git status -s)" ]]
 then
     git_setup
 


### PR DESCRIPTION
This PR

* [x] uses `git status -s` to check for untracked/modified files

Fixes #16.

💁‍♂ For reference, see https://remarkablemark.org/blog/2017/10/12/check-git-dirty/.