### PR TITLE
Add "repository" option for custom repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Add the following step at the end of your job.
 
     # Optional glob pattern of files which should be added to the commit
     file_pattern: src/\*.js
+
+    # Optional repository path
+    repository: .
+
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: File pattern used for "git add"
     required: false
     default: '.'
+  repository:
+    description: Path to repository
+    required: false
+    default: '.'
 
 runs:
   using: 'docker'
@@ -26,6 +30,7 @@ runs:
     - ${{ inputs.commit_options }}
     - ${{ inputs.branch }}
     - ${{ inputs.file_pattern }}
+    - ${{ inputs.repository }}
 
 branding:
   icon: 'git-commit'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,10 @@ EOF
     git config --global user.name "GitHub Actions"
 }
 
+echo "INPUT_REPOSITORY value: $INPUT_REPOSITORY";
+
+cd $INPUT_REPOSITORY
+
 # This section only runs if there have been file changes
 echo "Checking for uncommitted changes in the git working tree."
 if [[ -n "$(git status -s)" ]]


### PR DESCRIPTION
There are usage cases when repository should be checked out in another repository (e.g. you copy files from one repo to another -- see workflow link below)

Tested here:

* workflow: https://github.com/yelizariev/addons-yelizariev/blob/275e1c789b681080543f4d8afc375fc539d60e21/.github/workflows/itpp-runbot-install.yml
* logs: https://github.com/yelizariev/addons-yelizariev/commit/275e1c789b681080543f4d8afc375fc539d60e21/checks?check_suite_id=351048628
* created commit: https://github.com/yelizariev/addons-yelizariev/commit/7e8e26d5668953574e9bffa8ec7f48e5ea46fffc