### PR TITLE
allow custom author

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-auto-commit-action
 
 This GitHub Action automatically commits files which have been changed during a Workflow run and pushes the Commit back to GitHub.
-The Committer is "GitHub Actions <actions@github.com>" and the Author of the Commit is "Your GitHub Username <github_username@users.noreply.github.com>.
+Default committer and author is "GitHub Actions <actions@github.com>".
 
 If no changes are available, the Actions does nothing.
 
@@ -19,6 +19,11 @@ Add the following step at the end of your job.
   with:
     commit_message: Apply automatic changes
     branch: ${{ github.head_ref }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Optional committer info
+    commit_author_name: "My Bot"
+    commit_author_email: "bot@example.com"
 
     # Optional git params
     commit_options: '--no-verify --signoff'
@@ -28,9 +33,6 @@ Add the following step at the end of your job.
 
     # Optional repository path
     repository: .
-
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 You **do not** have to create a new secret called `GITHUB_TOKEN` in your repository. `GITHUB_TOKEN` is a special token GitHub creates automatically during an Action run. (See [the documentation](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) for details)

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,20 @@ inputs:
   commit_message:
     description: Commit message
     required: true
+  commit_author_email:
+    description: Author's email
+    required: true
+    default: actions@github.com
+  commit_author_name:
+    description: Author Name
+    required: true
+    default: Github Actions
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false
+  github_token:
+    description: Github Token
+    required: true
   branch:
     description: Branch name where changes should be pushed too
     required: true
@@ -25,12 +36,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.commit_message }}
-    - ${{ inputs.commit_options }}
-    - ${{ inputs.branch }}
-    - ${{ inputs.file_pattern }}
-    - ${{ inputs.repository }}
 
 branding:
   icon: 'git-commit'

--- a/lib.sh
+++ b/lib.sh
@@ -14,16 +14,16 @@ _setup_git ( ) {
   cat <<- EOF > $HOME/.netrc
         machine github.com
         login $GITHUB_ACTOR
-        password $GITHUB_TOKEN
+        password $INPUT_GITHUB_TOKEN
 
         machine api.github.com
         login $GITHUB_ACTOR
-        password $GITHUB_TOKEN
+        password $INPUT_GITHUB_TOKEN
 EOF
     chmod 600 $HOME/.netrc
 
-    git config --global user.email "actions@github.com"
-    git config --global user.name "GitHub Actions"
+    git config --global user.email "$INPUT_COMMIT_AUTHOR_EMAIL"
+    git config --global user.name "$INPUT_COMMIT_AUTHOR_NAME"
 }
 
 _switch_to_branch() {
@@ -40,7 +40,7 @@ _add_files() {
 
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
-    git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+    git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR_NAME <$INPUT_COMMIT_AUTHOR_EMAIL>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
 }
 
 _push_to_github() {


### PR DESCRIPTION
Updates:

* Move token to inputs
* add two args: ``commit_author_name``, ``commit_author_email``'
* merge notion "commiter" and "author" for sake of settings simplicity
* entrypoints args are not used, so delete it

Motivation:

default token has limitations. For example, it doesn't trigger deployment of Github Pages. The solution is using a custom token. But it doesn't work without changing the committer email. But as we change committer, it makes sense to change the author too. 

Tested here:

* config: https://github.com/yelizariev/git-auto-commit-action-demo-app/blob/e7eb68ead32da88c145c9fff537f972cf99b256a/.github/workflows/format_php.yml
* logs: https://github.com/yelizariev/git-auto-commit-action-demo-app/runs/374449479
* created commit: https://github.com/yelizariev/git-auto-commit-action-demo-app/commit/ac6919746c4b5582dd0328a86ed25f9cb8677283