### PR TITLE
Add Options to change Commit User Name and Email and Author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/stefanzweifel/git-auto-commit-action/compare/v2.5.0...HEAD)
 
+### Added
+- Add `commit_user_name`, `commit_user_email` and `commit_author` input options for full customzation on how the commit is being created [#39](https://github.com/stefanzweifel/git-auto-commit-action/pull/39)
+
 ### Removed
 - Remove the need of a GITHUB_TOKEN. Users now have to use `actions/checkout@v2` or higher [#36](https://github.com/stefanzweifel/git-auto-commit-action/pull/36)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Add the following step at the end of your job.
     # Optional commit user settings
     commit_user_name: My GitHub Actions Bot
     commit_user_email: my-github-actions-bot@example.org
+    commit_author: Author <actions@gitub.com>
 
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Add the following step at the end of your job.
     # Optional repository path
     repository: .
 
+    # Optional commit user settings
+    commit_user_name: My GitHub Actions Bot
+    commit_user_email: my-github-actions-bot@example.org
+
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-auto-commit-action
 
-This GitHub Action automatically commits files which have been changed during a Workflow run and pushes the Commit back to GitHub.
-The Committer is "GitHub Actions <actions@github.com>" and the Author of the Commit is "Your GitHub Username <github_username@users.noreply.github.com>.
+This GitHub Action automatically commits files which have been changed during a Workflow run and pushes the commit back to GitHub.
+The default committer is "GitHub Actions <actions@github.com>" and the default author of the commit is "Your GitHub Username <github_username@users.noreply.github.com>".
 
 If no changes are detected, the Action does nothing.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the following step at the end of your job.
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You **do not** have to create a new secret called `GITHUB_TOKEN` in your repository. `GITHUB_TOKEN` is a special token GitHub creates automatically during a Workflow run. (See [the documentation](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) for details)
+You **do not** have to create a new secret called `GITHUB_TOKEN` in your repository. `GITHUB_TOKEN` is a special token GitHub creates automatically during a Workflow run. (See [the documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token) for details)
 
 The Action will only commit files back, if changes are available. The resulting commit **will not trigger** another GitHub Actions Workflow run!
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Add the following step at the end of your job.
     # Optional glob pattern of files which should be added to the commit
     file_pattern: src/\*.js
 
-    # Optional repository path
+    # Optional local file path to the repository
     repository: .
 
-    # Optional commit user settings
+    # Optional commit user and author settings
     commit_user_name: My GitHub Actions Bot
     commit_user_email: my-github-actions-bot@example.org
     commit_author: Author <actions@gitub.com>

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,14 @@ inputs:
     description: Path to git repository
     required: false
     default: '.'
+  commit_user_name:
+    description: Name used for the commit user
+    required: false
+    default: GitHub Actions
+  commit_user_email:
+    description: Email address used for the commit user
+    required: false
+    default: actions@github.com
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -7,18 +7,18 @@ inputs:
   commit_message:
     description: Commit message
     required: true
+  branch:
+    description: Git branch name, where changes should be pushed too.
+    required: true
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false
-  branch:
-    description: Branch name where changes should be pushed too
-    required: true
   file_pattern:
-    description: File pattern used for "git add"
+    description: File pattern used for `git add`. For example `src/\*.js`
     required: false
     default: '.'
   repository:
-    description: Path to git repository
+    description: Local file path to the git repository. Defaults to the current directory (`.`)
     required: false
     default: '.'
   commit_user_name:
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: actions@github.com
   commit_author:
-    description: Value used for the commit author
+    description: Value used for the commit author. Defaults to the username of whoever triggered this workflow run.
     required: false
     default: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Email address used for the commit user
     required: false
     default: actions@github.com
+  commit_author:
+    description: Value used for the commit author
+    required: false
+    default: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ _add_files() {
 
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
-    git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+    git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
 }
 
 _push_to_github() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,8 +44,8 @@ _setup_git ( ) {
 EOF
     chmod 600 $HOME/.netrc
 
-    git config --global user.email "actions@github.com"
-    git config --global user.name "GitHub Actions"
+    git config --global user.name "$INPUT_COMMIT_USER_NAME"
+    git config --global user.email "$INPUT_COMMIT_USER_EMAIL"
 }
 
 _switch_to_branch() {


### PR DESCRIPTION
This PR adds 3 new options:

- `commit_user_name`
- `commit_user_email`
- `commit_author`

These `commit_user_*` options allow users to customize what user is associated with commit. By default, the commit user is `GitHub Actions <actions@github.com>`.

The `commit_author` option allows user to customize the author of the commit. It defaults to `Your GitHub Username <github_username@users.noreply.github.com>`. (`github_username` refers to the user which triggered the workflow run)

## Related Issues 
- #29 

## TODOs

- [x] Tests
- [x] How should we handle `--author`? Additional options? If-else condition?