### PR TITLE
Make branch option optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `commit_user_name`, `commit_user_email` and `commit_author` input options for full customzation on how the commit is being created [#39](https://github.com/stefanzweifel/git-auto-commit-action/pull/39)
 
+### Changed
+- Make the `branch` input option optional [#41](https://github.com/stefanzweifel/git-auto-commit-action/pull/41)
+
 ### Removed
 - Remove the need of a GITHUB_TOKEN. Users now have to use `actions/checkout@v2` or higher [#36](https://github.com/stefanzweifel/git-auto-commit-action/pull/36)
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ This Action has been inspired and adapted from the [auto-commit](https://github.
 Add the following step at the end of your job.
 
 ```yaml
-- uses: stefanzweifel/git-auto-commit-action@v2.5.0
+- uses: stefanzweifel/git-auto-commit-action@v3.0.0
   with:
     commit_message: Apply automatic changes
+
+    # Optional name of the branch the commit should be pushed to
+    # Required if Action is used in Workflow listening to the `pull_request` event
     branch: ${{ github.head_ref }}
 
     # Optional git params
@@ -65,10 +68,30 @@ jobs:
     - name: Run php-cs-fixer
       uses: docker://oskarstark/php-cs-fixer-ga
 
-    - uses: stefanzweifel/git-auto-commit-action@v2.5.0
+    - uses: stefanzweifel/git-auto-commit-action@v3.0.0
       with:
         commit_message: Apply php-cs-fixer changes
         branch: ${{ github.head_ref }}
+```
+
+```yaml
+name: php-cs-fixer
+
+on: push
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run php-cs-fixer
+      uses: docker://oskarstark/php-cs-fixer-ga
+
+    - uses: stefanzweifel/git-auto-commit-action@v3.0.0
+      with:
+        commit_message: Apply php-cs-fixer changes
 ```
 
 ### Inputs

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   branch:
     description: Git branch name, where changes should be pushed too.
     required: false
-    default: null
+    default: ''
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ inputs:
     required: true
   branch:
     description: Git branch name, where changes should be pushed too.
-    required: true
+    required: false
+    default: ${GITHUB_REF:11}
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: Commit message
     required: true
   branch:
-    description: Git branch name, where changes should be pushed too.
+    description: Git branch name, where changes should be pushed too. Required if Action is used on the `pull_request` event
     required: false
     default: ''
   commit_options:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   branch:
     description: Git branch name, where changes should be pushed too.
     required: false
-    default: ${GITHUB_REF:11}
+    default: null
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,11 +55,11 @@ _local_commit() {
 }
 
 _push_to_github() {
-    if [ -z $INPUT_BRANCH ]
+    if [ -n "$INPUT_BRANCH" ]
     then
-        git push --set-upstream origin "HEAD:$INPUT_BRANCH"
-    else
         git push origin
+    else
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH"
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,9 +57,9 @@ _local_commit() {
 _push_to_github() {
     if [ -z $INPUT_BRANCH ]
     then
-        git push origin
-    else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+    else
+        git push origin
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ _local_commit() {
 }
 
 _push_to_github() {
-    if [ -n "$INPUT_BRANCH" ]
+    if [ -z "$INPUT_BRANCH" ]
     then
         git push --set-upstream origin "HEAD:$INPUT_BRANCH"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ _local_commit() {
 }
 
 _push_to_github() {
-    if [ -n "$INPUT_BRANCH" ]
+    if [ -z "$INPUT_BRANCH" ]
     then
         git push origin
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,9 +57,9 @@ _local_commit() {
 _push_to_github() {
     if [ -n "$INPUT_BRANCH" ]
     then
-        git push origin
-    else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+    else
+        git push origin
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,12 @@ _local_commit() {
 }
 
 _push_to_github() {
-    git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+    if [ -z $INPUT_BRANCH ]
+    then
+        git push origin
+    else
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+    fi
 }
 
 _main

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,12 +55,14 @@ _local_commit() {
 }
 
 _push_to_github() {
-    if [ -z "$INPUT_BRANCH" ]
-    then
-        git push --set-upstream origin "HEAD:$INPUT_BRANCH"
-    else
-        git push origin
-    fi
+    git push origin
+
+    # if [ -z "$INPUT_BRANCH" ]
+    # then
+    #     git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+    # else
+    #     git push origin
+    # fi
 }
 
 _main

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,14 +55,12 @@ _local_commit() {
 }
 
 _push_to_github() {
-    git push origin
-
-    # if [ -z "$INPUT_BRANCH" ]
-    # then
-    #     git push --set-upstream origin "HEAD:$INPUT_BRANCH"
-    # else
-    #     git push origin
-    # fi
+    if [ -n "$INPUT_BRANCH" ]
+    then
+        git push origin
+    else
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+    fi
 }
 
 _main


### PR DESCRIPTION
This PR updates the `_push_to_github`-function and the call to `git push` to make the `branch` input option optional.

If no `branch` name has been given, we now just execute `git push origin` without an explicit branch name.

---

I've tested this with `actions/checkouts@v2` and with Workflows listening to the `push` event, and it works great.

- Workflow Run: https://github.com/stefanzweifel/git-auto-commit-action-demo-app/runs/430150745
- Workflow File: https://github.com/stefanzweifel/git-auto-commit-action-demo-app/blob/e062ad8e5b0c7087808313c9930240c8987cba95/.github/workflows/format_php.yml
- Created Commit: https://github.com/stefanzweifel/git-auto-commit-action-demo-app/commit/60d40ed3077b5eb921e35f8593ff08d7577a0ebf

---

Closes #27 