### PR TITLE
Feature: Tag commit created by the Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Add the following step at the end of your job.
     commit_user_name: My GitHub Actions Bot
     commit_user_email: my-github-actions-bot@example.org
     commit_author: Author <actions@gitub.com>
+
+    # Optional. If value is set, the commit will be tagged with the given value
+    tagging_message: 'v1.0.0'
 ```
 
 The Action will only commit files back, if changes are available. The resulting commit **will not trigger** another GitHub Actions Workflow run!

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add the following step at the end of your job.
     commit_user_email: my-github-actions-bot@example.org
     commit_author: Author <actions@gitub.com>
 
-    # Optional. If value is set, the commit will be tagged with the given value
+    # Optional tag message. Will create and push a new tag to the remote repository
     tagging_message: 'v1.0.0'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
   tagging_message:
-    description: Value used for a git tag. Keep it empty to not tag the commit.
+    description: Message used to create a new git tag with the commit. Keep this empty, if no tag should be created.
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Value used for the commit author. Defaults to the username of whoever triggered this workflow run.
     required: false
     default: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+  tagging_message:
+    description: Value used for a git tag. Keep it empty to not tag the commit.
+    required: false
+    default: ''
 
 outputs:
   changes_detected:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,6 +62,8 @@ _local_commit() {
 }
 
 _tag_commit() {
+    echo "INPUT_TAGGING_MESSAGE: ${INPUT_TAGGING_MESSAGE}"
+
     if [ -n "$INPUT_TAGGING_MESSAGE" ]
     then
         git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,10 +62,8 @@ _local_commit() {
 }
 
 _tag_commit() {
-    if [ -z "$INPUT_TAGGING_MESSAGE" ]
+    if [ -n "$INPUT_TAGGING_MESSAGE" ]
     then
-        # No tag name given. Do nothing.
-    else
         git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,8 @@ _main() {
 
         _local_commit
 
+        _tag_commit
+
         _push_to_github
     else
 
@@ -57,6 +59,15 @@ _add_files() {
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
     git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+}
+
+_tag_commit() {
+    if [ -z "$INPUT_TAGGING_MESSAGE" ]
+    then
+        # No tag name given. Do nothing.
+    else
+        git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"
+    fi
 }
 
 _push_to_github() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,9 +62,9 @@ _local_commit() {
 _push_to_github() {
     if [ -z "$INPUT_BRANCH" ]
     then
-        git push origin
+        git push origin --tags
     else
-        git push --set-upstream origin "HEAD:$INPUT_BRANCH"
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags
     fi
 }
 


### PR DESCRIPTION
This PR adds a new input-option `tagging_message` to the Action.

If filled, the Action will create a new Tag with the supplied tag message. The tag will then be pushed to the remote repository.

Refs #47 