### PR TITLE
Fix: Push branch to repository if no branch name is given and no tagging message is set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,7 @@ _tag_commit() {
     then
         git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"
     else
-        echo " No tagging message supplied. Not tag will be added"
+        echo " No tagging message supplied. No tag will be added."
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,12 +67,15 @@ _tag_commit() {
     if [ -n "$INPUT_TAGGING_MESSAGE" ]
     then
         git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"
+    else
+        echo " No tagging message supplied. Not tag will be added"
     fi
 }
 
 _push_to_github() {
     if [ -z "$INPUT_BRANCH" ]
     then
+        echo "git push origin without branch name"
         git push origin --tags
     else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,14 +75,15 @@ _tag_commit() {
 _push_to_github() {
     if [ -z "$INPUT_BRANCH" ]
     then
+        git push origin --all --tags
 
         # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set
-        if [ -n "$INPUT_TAGGING_MESSAGE" ]
-        then
-             git push origin --tags
-        else
-             git push origin
-        fi
+        # if [ -n "$INPUT_TAGGING_MESSAGE" ]
+        # then
+        #      git push origin --tags
+        # else
+        #      git push origin
+        # fi
 
     else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,8 +75,15 @@ _tag_commit() {
 _push_to_github() {
     if [ -z "$INPUT_BRANCH" ]
     then
-        echo "git push origin without branch name"
-        git push origin
+
+        # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set
+        if [ -n "$INPUT_TAGGING_MESSAGE" ]
+        then
+             git push origin --tags
+        else
+             git push origin
+        fi
+
     else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,7 +76,7 @@ _push_to_github() {
     if [ -z "$INPUT_BRANCH" ]
     then
         echo "git push origin without branch name"
-        git push origin --tags
+        git push origin
     else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,15 +75,13 @@ _tag_commit() {
 _push_to_github() {
     if [ -z "$INPUT_BRANCH" ]
     then
-        git push origin --all --tags
-
-        # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set
-        # if [ -n "$INPUT_TAGGING_MESSAGE" ]
-        # then
-        #      git push origin --tags
-        # else
-        #      git push origin
-        # fi
+        # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set
+        if [ -n "$INPUT_TAGGING_MESSAGE" ]
+        then
+             git push origin --tags
+        else
+             git push origin
+        fi
 
     else
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags


### PR DESCRIPTION
Just executing `git push origin --tags` seems to have broken the Action.
Adding a if/else-clauses seem to fix the issue.

See #53 