### PR TITLE
Remove unnecessary escape

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ _main() {
 
     if _git_is_dirty; then
 
-        echo \"::set-output name=changes_detected::true\"
+        echo "::set-output name=changes_detected::true"
 
         _setup_git
 
@@ -22,7 +22,7 @@ _main() {
         _push_to_github
     else
 
-        echo \"::set-output name=changes_detected::false\"
+        echo "::set-output name=changes_detected::false"
 
         echo "Working tree clean. Nothing to commit."
     fi


### PR DESCRIPTION
GitHub Action will never actually set output result with the escaped quote, and ${{steps.<step_id>.outputs.changes_detected}} will always be null.

You could check the difference from the debug log between the current version and my fork.

Current Version
https://github.com/bangumi-data/bangumi-data/runs/557011365?check_suite_focus=true
<img width="873" alt="image" src="https://user-images.githubusercontent.com/3823149/78331888-86409380-75b9-11ea-8434-91ab89c3c723.png">

Forked Version
https://github.com/bangumi-data/bangumi-data/runs/557156710?check_suite_focus=true
<img width="768" alt="image" src="https://user-images.githubusercontent.com/3823149/78331922-9b1d2700-75b9-11ea-875e-910e4f060b93.png">

