### PR TITLE
Place git user configuration inline before commit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,6 @@ _main() {
 
         echo "::set-output name=changes_detected::true"
 
-        _setup_git
-
         _switch_to_branch
 
         _add_files
@@ -38,12 +36,6 @@ _git_is_dirty() {
     [ -n "$(git status -s)" ]
 }
 
-# Set up git user configuration
-_setup_git ( ) {
-    git config --global user.name "$INPUT_COMMIT_USER_NAME"
-    git config --global user.email "$INPUT_COMMIT_USER_EMAIL"
-}
-
 _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
@@ -58,7 +50,7 @@ _add_files() {
 
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
-    git commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+    git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
 }
 
 _tag_commit() {


### PR DESCRIPTION
We don't need to set up git in a separate step, because the config
`user.name` and `user.email` can be supplied before the `commit`
instruction.

This has the added benefit of not overriding the git config for the 
user account which is running the action, and might be configured.