### PR TITLE
Checkout local temp branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ _setup_git ( ) {
 }
 
 _switch_to_branch() {
-    # echo "INPUT_BRANCH value: $INPUT_BRANCH";
+    echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Switch to branch from current Workflow run
     # git checkout $INPUT_BRANCH

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,10 @@ _tag_commit() {
 }
 
 _push_to_github() {
+
+    echo "INPUT_BRANCH value: $INPUT_BRANCH";
+    echo "push_to_github";
+
     if [ -z "$INPUT_BRANCH" ]
     then
         # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,7 @@ _push_to_github() {
         fi
     else
         echo "::debug::Push commit to remote branch $INPUT_BRANCH"
+        git pull origin "HEAD:$INPUT_BRANCH"
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,9 @@ _push_to_github() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
     echo "push_to_github";
 
+    echo "::debug __push_to_github"
+
+
     if [ -z "$INPUT_BRANCH" ]
     then
         # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,11 +48,13 @@ _switch_to_branch() {
 
 _add_files() {
     echo "INPUT_FILE_PATTERN: ${INPUT_FILE_PATTERN}"
+    echo "::debug::File pattern ${INPUT_FILE_PATTERN}"
     git add "${INPUT_FILE_PATTERN}"
 }
 
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
+    echo "::debug::Commit Options ${INPUT_COMMIT_OPTIONS}"
     git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
 }
 
@@ -61,6 +63,7 @@ _tag_commit() {
 
     if [ -n "$INPUT_TAGGING_MESSAGE" ]
     then
+        echo "::debug::Create tag $INPUT_TAGGING_MESSAGE"
         git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"
     else
         echo " No tagging message supplied. No tag will be added."
@@ -70,10 +73,7 @@ _tag_commit() {
 _push_to_github() {
 
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
-    echo "push_to_github";
-
-    echo "::debug __push_to_github"
-
+    echo "::debug::__push_to_github"
 
     if [ -z "$INPUT_BRANCH" ]
     then
@@ -84,8 +84,8 @@ _push_to_github() {
         else
              git push origin
         fi
-
     else
+        echo "::debug::Push commit to remote branch $INPUT_BRANCH"
         git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,10 +45,13 @@ _setup_git ( ) {
 }
 
 _switch_to_branch() {
-    echo "INPUT_BRANCH value: $INPUT_BRANCH";
+    # echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Switch to branch from current Workflow run
-    git checkout $INPUT_BRANCH
+    # git checkout $INPUT_BRANCH
+
+    git checkout -b git-auto-commit-temp-branch
+
 }
 
 _add_files() {


### PR DESCRIPTION
An attempt to remove the dependency on the correct configuration of `actions/checkout`.

### Goals

- Use the Action in the same workflow file both for `push` and the `pull_request`-event.
- Action should work as expected, without explicitly setting the `ref` input on the `actions/checkout` step.

See #58 