### PR TITLE
Fix Issue with Commit Options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false
+    default: ''
   file_pattern:
     description: File pattern used for `git add`. For example `src/\*.js`
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,10 +52,12 @@ _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}";
     echo "::debug::Apply commit options ${INPUT_COMMIT_OPTIONS}";
 
+    INPUT_COMMIT_OPTIONS_ARRAY=( $INPUT_COMMIT_OPTIONS );
+
     git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" \
         commit -m "$INPUT_COMMIT_MESSAGE" \
         --author="$INPUT_COMMIT_AUTHOR" \
-        ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"};
+        ${INPUT_COMMIT_OPTIONS:+"${INPUT_COMMIT_OPTIONS_ARRAY[@]}"};
 }
 
 _tag_commit() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,8 +55,8 @@ _local_commit() {
 
     if [ -n "$INPUT_COMMIT_OPTIONS" ]
     then
-        echo "::debug::Apply commit options $INPUT_COMMIT_OPTIONS";
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS";
+        echo "::debug::Apply commit options ${INPUT_COMMIT_OPTIONS}";
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "${INPUT_COMMIT_OPTIONS}";
     else
         git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,8 +51,11 @@ _add_files() {
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}";
 
+    git --version;
+
     if [ -n "$INPUT_COMMIT_OPTIONS" ]
     then
+        echo "::debug::Apply commit options $INPUT_COMMIT_OPTIONS";
         git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS";
     else
         git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ _local_commit() {
     if [ -n "$INPUT_COMMIT_OPTIONS" ]
     then
         echo "::debug::Apply commit options $INPUT_COMMIT_OPTIONS";
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS";
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" --signoff --no-verify;
     else
         git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ _main() {
 
     if _git_is_dirty; then
 
-        echo "::set-output name=changes_detected::true"
+        echo "::set-output name=changes_detected::true";
 
         _switch_to_branch
 
@@ -20,16 +20,16 @@ _main() {
         _push_to_github
     else
 
-        echo "::set-output name=changes_detected::false"
+        echo "::set-output name=changes_detected::false";
 
-        echo "Working tree clean. Nothing to commit."
+        echo "Working tree clean. Nothing to commit.";
     fi
 }
 
 
 _switch_to_repository() {
     echo "INPUT_REPOSITORY value: $INPUT_REPOSITORY";
-    cd $INPUT_REPOSITORY
+    cd $INPUT_REPOSITORY;
 }
 
 _git_is_dirty() {
@@ -40,22 +40,22 @@ _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Switch to branch from current Workflow run
-    git checkout $INPUT_BRANCH
+    git checkout $INPUT_BRANCH;
 }
 
 _add_files() {
-    echo "INPUT_FILE_PATTERN: ${INPUT_FILE_PATTERN}"
-    git add "${INPUT_FILE_PATTERN}"
+    echo "INPUT_FILE_PATTERN: ${INPUT_FILE_PATTERN}";
+    git add "${INPUT_FILE_PATTERN}";
 }
 
 _local_commit() {
-    echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
+    echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}";
 
     if [ -n "$INPUT_COMMIT_OPTIONS" ]
     then
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS"
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS";
     else
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR"
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";
     fi
 }
 
@@ -64,10 +64,10 @@ _tag_commit() {
 
     if [ -n "$INPUT_TAGGING_MESSAGE" ]
     then
-        echo "::debug::Create tag $INPUT_TAGGING_MESSAGE"
-        git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE"
+        echo "::debug::Create tag $INPUT_TAGGING_MESSAGE";
+        git tag -a "$INPUT_TAGGING_MESSAGE" -m "$INPUT_TAGGING_MESSAGE";
     else
-        echo " No tagging message supplied. No tag will be added."
+        echo " No tagging message supplied. No tag will be added.";
     fi
 }
 
@@ -77,16 +77,16 @@ _push_to_github() {
         # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set
         if [ -n "$INPUT_TAGGING_MESSAGE" ]
         then
-            echo "::debug::git push origin --tags"
-            git push origin --tags
+            echo "::debug::git push origin --tags";
+            git push origin --tags;
         else
-            echo "::debug::git push origin"
-            git push origin
+            echo "::debug::git push origin";
+            git push origin;
         fi
 
     else
-        echo "::debug::Push commit to remote branch $INPUT_BRANCH"
-        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags
+        echo "::debug::Push commit to remote branch $INPUT_BRANCH";
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags;
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ _local_commit() {
     if [ -n "$INPUT_COMMIT_OPTIONS" ]
     then
         echo "::debug::Apply commit options $INPUT_COMMIT_OPTIONS";
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" --signoff --no-verify;
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS";
     else
         git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,13 @@ _add_files() {
 
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}"
-    git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+
+    if [ -n "$INPUT_COMMIT_OPTIONS" ]
+    then
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "$INPUT_COMMIT_OPTIONS"
+    else
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR"
+    fi
 }
 
 _tag_commit() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,10 @@ _local_commit() {
     if [ -n "$INPUT_COMMIT_OPTIONS" ]
     then
         echo "::debug::Apply commit options ${INPUT_COMMIT_OPTIONS}";
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "${INPUT_COMMIT_OPTIONS}";
+
+        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "Message" "${INPUT_COMMIT_OPTIONS}";
+
+        # git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "${INPUT_COMMIT_OPTIONS}";
     else
         git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,19 +50,12 @@ _add_files() {
 
 _local_commit() {
     echo "INPUT_COMMIT_OPTIONS: ${INPUT_COMMIT_OPTIONS}";
+    echo "::debug::Apply commit options ${INPUT_COMMIT_OPTIONS}";
 
-    git --version;
-
-    if [ -n "$INPUT_COMMIT_OPTIONS" ]
-    then
-        echo "::debug::Apply commit options ${INPUT_COMMIT_OPTIONS}";
-
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "Message" "${INPUT_COMMIT_OPTIONS}";
-
-        # git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR" "${INPUT_COMMIT_OPTIONS}";
-    else
-        git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" commit -m "$INPUT_COMMIT_MESSAGE" --author="$INPUT_COMMIT_AUTHOR";
-    fi
+    git -c user.name="$INPUT_COMMIT_USER_NAME" -c user.email="$INPUT_COMMIT_USER_EMAIL" \
+        commit -m "$INPUT_COMMIT_MESSAGE" \
+        --author="$INPUT_COMMIT_AUTHOR" \
+        ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"};
 }
 
 _tag_commit() {


### PR DESCRIPTION
This PR fixes the problem raised in #61.

Instead of passing the given options directly to the `git-commit`-command, we convert them to an array.