### PR TITLE
Bundle limitations and gotchas together in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Add the following step at the end of your job, after other steps that might add 
     # Required
     commit_message: Apply automatic changes
 
-    # Optional name of the branch the commit should be pushed to
-    # Required for almost all non-`push` events, eg. `pull_request`, `schedule`
+    # Optional name of another branch the commit should be pushed to
     branch: ${{ github.head_ref }}
 
     # Optional git params
@@ -46,7 +45,7 @@ Add the following step at the end of your job, after other steps that might add 
 In this example, we're running `php-cs-fixer` in a PHP project to fix the codestyle automatically,
 then commit possible changed files back to the repository.
 
-Note that we explicitly specify `${{ github.head_ref }}` in both the checkout and the commit Action.
+Note that we explicitly specify `${{ github.head_ref }}` in the checkout Action.
 This is required in order to work with the `pull_request` event (or any other non-`push` event).
 
 ```yaml
@@ -73,7 +72,6 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4.1.6
       with:
         commit_message: Apply php-cs-fixer changes
-        branch: ${{ github.head_ref }}
 ```
 
 ## Limitations & Gotchas
@@ -88,20 +86,6 @@ In non-`push` events, such as `pull_request`, make sure to specify the `ref` to 
   with:
     ref: ${{ github.head_ref }}
 ```
-
-### Specify the branch name
-
-It is highly recommended to always specify the `branch` option explicitly.
-While the default setting works for `push` events, other events such as `pull_request` require it to work correctly.
-
-```yaml
-- uses: stefanzweifel/git-auto-commit-action@v4.1.6
-  with:
-    commit_message: Some automated code change
-    branch: ${{ github.head_ref }}
-```
-
-This Action does not contain magic and can't easily determine to which branch a commit should be pushed to. 🔮.
 
 ### Commits of this Action do not trigger new Workflow runs
 
@@ -138,7 +122,7 @@ You can use these outputs to trigger other Actions in your Workflow run based on
 
 ### Action does not push commit to repository
 
-Make sure to [checkout the correct branch](#checkout-the-correct-branch) and [specify the branch name](#specify-the-branch-name).
+Make sure to [checkout the correct branch](#checkout-the-correct-branch).
 
 ### Action does not push commit to repository: Authentication Issue
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following step at the end of your job, after other steps that might add 
     commit_message: Apply automatic changes
 
     # Optional branch to push to, defaults to the current branch
-    branch: ${{ github.head_ref }}
+    branch: feature-123
 
     # Optional git params
     commit_options: '--no-verify --signoff'
@@ -42,8 +42,7 @@ Add the following step at the end of your job, after other steps that might add 
 
 ## Example
 
-In this example, we're running `php-cs-fixer` in a PHP project to fix the codestyle automatically,
-then commit possible changed files back to the repository.
+In this example, we're running `php-cs-fixer` in a PHP project to fix the codestyle automatically, then commit possible changed files back to the repository.
 
 Note that we explicitly specify `${{ github.head_ref }}` in the checkout Action.
 This is required in order to work with the `pull_request` event (or any other non-`push` event).
@@ -86,6 +85,8 @@ In non-`push` events, such as `pull_request`, make sure to specify the `ref` to 
   with:
     ref: ${{ github.head_ref }}
 ```
+
+You have to do this do avoid that the `checkout`-Action clones your repository in a detached state.
 
 ### Commits of this Action do not trigger new Workflow runs
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ storing the token as a secret in your repository and then passing the new token 
 
 ### Unable to commit into PRs from forks
 
-GitHub currently prohibits Actions like this to push commits to forks, even when they created a PR and allow edits.
+GitHub currently prohibits Actions to push commits to forks, even when they created a PR and allow edits.
 See [issue #25](https://github.com/stefanzweifel/git-auto-commit-action/issues/25) for more information.
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-auto-commit Action
 
-> The GitHub Action for commiting files for the 80% use case.
+> The GitHub Action for committing files for the 80% use case.
 
 This GitHub Action automatically commits files which have been changed during a Workflow run and pushes the commit back to GitHub.  
 The default committer is "GitHub Actions <actions@github.com>", and the default author of the commit is "Your GitHub Username <github_username@users.noreply.github.com>".
@@ -10,7 +10,7 @@ This Action has been inspired and adapted from the [auto-commit](https://github.
 
 ## Usage
 
-Add the following step at the end of your job, after the steps that actually change files.
+Add the following step at the end of your job, after other steps that might add or change files.
 
 ```yaml
 - uses: stefanzweifel/git-auto-commit-action@v4.1.6
@@ -41,7 +41,40 @@ Add the following step at the end of your job, after the steps that actually cha
     tagging_message: 'v1.0.0'
 ```
 
-The Action will only commit if files have changed.
+## Example
+
+In this example, we're running `php-cs-fixer` in a PHP project to fix the codestyle automatically,
+then commit possible changed files back to the repository.
+
+Note that we explicitly specify `${{ github.head_ref }}` in both the checkout and the commit Action.
+This is required in order to work with the `pull_request` event (or any other non-`push` event).
+
+```yaml
+name: php-cs-fixer
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+
+    - name: Run php-cs-fixer
+      uses: docker://oskarstark/php-cs-fixer-ga
+
+    - uses: stefanzweifel/git-auto-commit-action@v4.1.6
+      with:
+        commit_message: Apply php-cs-fixer changes
+        branch: ${{ github.head_ref }}
+```
 
 ## Limitations & Gotchas
 
@@ -83,41 +116,6 @@ storing the token as a secret in your repository and then passing the new token 
 
 GitHub currently prohibits Actions like this to push commits to forks, even when they created a PR and allow edits.
 See [issue #25](https://github.com/stefanzweifel/git-auto-commit-action/issues/25) for more information.
-
-## Example
-
-The most common use case for this Action is to create a new build of your project on GitHub Actions and commit the compiled files back to the repository.
-Another simple use case is to run automatic formatting and commit the fixes back to the repository.
-
-In this example, we're running `php-cs-fixer` in a PHP project, let the linter fix possible code issues, then commit the changed files back to the repository.
-
-Note that we explicitly specify `${{ github.head_ref }}` in both the checkout and the commit Action.
-This is required in order to work with the `pull_request` event (or any other non-`push` event).
-
-```yaml
-name: php-cs-fixer
-
-on:
-  pull_request:
-  push:
-
-jobs:
-  php-cs-fixer:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.head_ref }}
-
-    - name: Run php-cs-fixer
-      uses: docker://oskarstark/php-cs-fixer-ga
-
-    - uses: stefanzweifel/git-auto-commit-action@v4.1.6
-      with:
-        commit_message: Apply php-cs-fixer changes
-        branch: ${{ github.head_ref }}
-```
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the following step at the end of your job, after other steps that might add 
     # Required
     commit_message: Apply automatic changes
 
-    # Optional name of another branch the commit should be pushed to
+    # Optional branch to push to, defaults to the current branch
     branch: ${{ github.head_ref }}
 
     # Optional git params

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ In non-`push` events, such as `pull_request`, make sure to specify the `ref` to 
 It is highly recommended to always specify the `branch` option explicitly.
 While the default setting works for `push` events, other events such as `pull_request` require it to work correctly.
 
+```yaml
+- uses: stefanzweifel/git-auto-commit-action@v4.1.6
+  with:
+    commit_message: Some automated code change
+    branch: ${{ github.head_ref }}
+```
+
 This Action does not contain magic and can't easily determine to which branch a commit should be pushed to. 🔮.
 
 ### Commits of this Action do not trigger new Workflow runs


### PR DESCRIPTION
The documentation of this action is really good and has a lot of information. We can make it easier to use by putting a common example first, then clearly listing the limitations and possible gotchas.

I found that there was a bit of duplication, so i attempted to consolidate and distill it down to the essentials.

Thank you for this package!