### PR TITLE
Use github.head_ref as branch default value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   branch:
     description: Git branch name, where changes should be pushed too. Required if Action is used on the `pull_request` event
     required: false
-    default: ''
+    default: ${{ github.head_ref }}
   commit_options:
     description: Commit options (eg. --no-verify)
     required: false


### PR DESCRIPTION
`${{ github.head_ref }}` is only filled when a workflow listens to the `pull_request` event. However, it evaluates to an empty string when listening to other events (the same default value as the current version has).

By doing this change, the `branch`-input no longer must manually added to a workflow when listening to `pull_request`. But, the `actions/checkout` step still has to be updated and `ref` has to be added. Otherwise, the repo would be cloned in a detached head and this Action can't commit and push correctly

```
    - uses: actions/checkout@v2
      with:
        ref: ${{ github.head_ref }}
```

refs #73 

--- 

I'm not sure yet, if this is the right approach. 
Actions are basically just configuration code. I think being more explicit in that configuration code leads to less confusion and easier to understand workflows.

In addition, the user still needs to update the `checkout`-step. So a consumer can't just add 2-3 lines of code to add *one single step*. They have to update the rest of their workflow too. 🤔 
