### PR TITLE
Feature: Push Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ please update your Workflow configuration and usage of [`actions/checkout`](http
 
 Updating the `token` value with a Personal Access Token should fix your issues.
 
+## Action does not push to protected branch
+
+If your repository uses [protected branches](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) this Action will not be able to push to your repository.
+
+You have to enable force pushes to a protected branch (See [documentation](https://help.github.com/en/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)) and update your Workflow to to use force pushes like so.
+
+```yaml
+    - uses: stefanzweifel/git-auto-commit-action@v4.2.0
+      with:
+        commit_message: Apply php-cs-fixer changes
+        push_options: --force
+```
+
 ### No new workflows are triggered by the commit of this action
 
 This is due to limitations set up by GitHub, [commits of this Action do not trigger new Workflow runs](#commits-of-this-action-do-not-trigger-new-workflow-runs).

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Updating the `token` value with a Personal Access Token should fix your issues.
 
 If your repository uses [protected branches](https://help.github.com/en/github/administering-a-repository/configuring-protected-branches) this Action will not be able to push to your repository.
 
-You have to enable force pushes to a protected branch (See [documentation](https://help.github.com/en/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)) and update your Workflow to to use force pushes like so.
+You have to enable force pushes to a protected branch (See [documentation](https://help.github.com/en/github/administering-a-repository/enabling-force-pushes-to-a-protected-branch)) and update your Workflow to use force push like so.
 
 ```yaml
     - uses: stefanzweifel/git-auto-commit-action@v4.2.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the following step at the end of your job, after other steps that might add 
     # Optional branch to push to, defaults to the current branch
     branch: feature-123
 
-    # Optional git params
+    # Optional options appended to `git-commit`
     commit_options: '--no-verify --signoff'
 
     # Optional glob pattern of files which should be added to the commit
@@ -38,6 +38,9 @@ Add the following step at the end of your job, after other steps that might add 
     # Optional tag message 
     # Action will create and push a new tag to the remote repository and the defined branch
     tagging_message: 'v1.0.0'
+
+    # Optional options appended to `git-push`
+    push_options: '--force'
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: Message used to create a new git tag with the commit. Keep this empty, if no tag should be created.
     required: false
     default: ''
+  push_options:
+    description: Push options (eg. --force)
+    required: false
+    default: ''
 
 outputs:
   changes_detected:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,21 +73,27 @@ _tag_commit() {
 }
 
 _push_to_github() {
+
+    echo "INPUT_PUSH_OPTIONS: ${INPUT_PUSH_OPTIONS}";
+    echo "::debug::Apply push options ${INPUT_PUSH_OPTIONS}";
+
+    INPUT_PUSH_OPTIONS_ARRAY=( $INPUT_PUSH_OPTIONS );
+
     if [ -z "$INPUT_BRANCH" ]
     then
         # Only add `--tags` option, if `$INPUT_TAGGING_MESSAGE` is set
         if [ -n "$INPUT_TAGGING_MESSAGE" ]
         then
             echo "::debug::git push origin --tags";
-            git push origin --tags;
+            git push origin --tags ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
         else
             echo "::debug::git push origin";
-            git push origin;
+            git push origin ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
         fi
 
     else
         echo "::debug::Push commit to remote branch $INPUT_BRANCH";
-        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags;
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
     fi
 }
 


### PR DESCRIPTION
This PR adds a new `push_options`-input. It allows users to append their own options to the [git-push](https://git-scm.com/docs/git-push) command.

Closes #72 