### PR TITLE
Only check status of files matching file_pattern

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ _switch_to_repository() {
 }
 
 _git_is_dirty() {
-    [ -n "$(git status -s)" ]
+    [ -n "$(git status -s -- $INPUT_FILE_PATTERN)" ]
 }
 
 _switch_to_branch() {


### PR DESCRIPTION
Otherwise, if only files *not* matching the pattern are changed, a commit is attempted (after adding all zero files which match the pattern) and the `git commit` command fails.