### PR TITLE
Fix checking out branch names with / chars

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Switch to branch from current Workflow run
-    git checkout $INPUT_BRANCH;
+    git switch "$INPUT_BRANCH";
 }
 
 _add_files() {


### PR DESCRIPTION
If a branch has a file-path looking name, then `git checkout`
can get confused. `git switch` won't.