### PR TITLE
Better support branches with special characters in them

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,9 @@ _git_is_dirty() {
 _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
+    # Fetch remote to make sure that repo can be switched to the right branch.
+    git fetch;
+
     # Switch to branch from current Workflow run
     git checkout $INPUT_BRANCH;
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -98,6 +98,7 @@ main() {
     INPUT_SKIP_DIRTY_CHECK=true
 
     shellmock_expect git --type exact --match "status -s ."
+    shellmock_expect git --type exact --match "fetch"
     shellmock_expect git --type exact --match "checkout master"
     shellmock_expect git --type exact --match "add ."
     shellmock_expect git --type partial --match '-c'
@@ -109,10 +110,11 @@ main() {
 
     shellmock_verify
     [ "${capture[0]}" = "git-stub status -s -- ." ]
-    [ "${capture[1]}" = "git-stub checkout master" ]
-    [ "${capture[2]}" = "git-stub add ." ]
-    [ "${capture[3]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
-    [ "${capture[4]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout master" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
 
     # Failed Exit Code
     [ "$status" -ne 0 ]


### PR DESCRIPTION
Related to #106 this PR fixes a problem when a branch like `feature/name-of-the-feature` couldn't correctly been checked out by the Action.

Simply calling `git fetch` before calling `git checkout` seems to fix the problem. 🤷 