### PR TITLE
Expand existing BATS Test Suite to cover every feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "bats": "^1.1.0"
   },
   "scripts": {
-    "test": "bats tests"
+    "test": "rm -rf tests/tmpstubs && rm -rf tests/shellmock.* && bats tests"
   }
 }

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -237,3 +237,39 @@ main() {
     [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
 }
 
+@test "can-create-tag" {
+
+    INPUT_TAGGING_MESSAGE="v1.0.0"
+
+    touch "${test_repository}"/new-file-{1,2,3}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt M new-file-3.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout master"
+    shellmock_expect git --type partial --match "add ."
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push --set-upstream origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+
+    [ "${lines[6]}" = "INPUT_TAGGING_MESSAGE: v1.0.0" ]
+    [ "${lines[7]}" = "::debug::Create tag v1.0.0" ]
+    [ "${lines[10]}" = "::debug::Push commit to remote branch master" ]
+
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout master" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com tag -a v1.0.0 -m v1.0.0" ]
+    [ "${capture[6]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
+
+}
+

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -173,3 +173,34 @@ main() {
     [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
 }
 
+@test "git-commit-options-are-applied" {
+
+    INPUT_COMMIT_OPTIONS="--no-verify --signoff"
+
+    touch "${test_repository}"/new-file-{1,2}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout master"
+    shellmock_expect git --type partial --match "add"
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push --set-upstream origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+    [ "${lines[4]}" = "INPUT_COMMIT_OPTIONS: --no-verify --signoff" ]
+    [ "${lines[10]}" = "::debug::Push commit to remote branch master" ]
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout master" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com> --no-verify --signoff" ]
+    [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
+}
+

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -392,3 +392,48 @@ main() {
     [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
     [ "${capture[5]}" = "git-stub push origin" ]
 }
+
+@test "can-work-with-empty-branch-name-and-tags" {
+
+    INPUT_BRANCH=""
+    INPUT_TAGGING_MESSAGE="v2.0.0"
+
+    touch "${test_repository}"/new-file-{1,2,3}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt M new-file-3.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout"
+    shellmock_expect git --type partial --match "add ."
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+
+    [ "${lines[0]}" = "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}" ]
+    [ "${lines[1]}" = "::set-output name=changes_detected::true" ]
+    [ "${lines[2]}" = "INPUT_BRANCH value: " ]
+    [ "${lines[3]}" = "INPUT_FILE_PATTERN: ." ]
+    [ "${lines[4]}" = "INPUT_COMMIT_OPTIONS: " ]
+    [ "${lines[5]}" = "::debug::Apply commit options " ]
+    [ "${lines[6]}" = "INPUT_TAGGING_MESSAGE: v2.0.0" ]
+    [ "${lines[7]}" = "::debug::Create tag v2.0.0" ]
+    [ "${lines[8]}" = "INPUT_PUSH_OPTIONS: " ]
+    [ "${lines[9]}" = "::debug::Apply push options " ]
+    [ "${lines[10]}" = "::debug::git push origin --tags" ]
+
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com tag -a v2.0.0 -m v2.0.0" ]
+    [ "${capture[6]}" = "git-stub push origin --tags" ]
+
+}

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -204,3 +204,36 @@ main() {
     [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
 }
 
+@test "commit-user-and-author-settings-are-applied" {
+
+    INPUT_COMMIT_USER_NAME="A Single Test"
+    INPUT_COMMIT_USER_EMAIL="single-test@github.com"
+    INPUT_COMMIT_AUTHOR="A Single Test <single@users.noreply.github.com>"
+
+    touch "${test_repository}"/new-file-{1,2}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout master"
+    shellmock_expect git --type partial --match "add"
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push --set-upstream origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+
+    [ "${lines[10]}" = "::debug::Push commit to remote branch master" ]
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout master" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=A Single Test -c user.email=single-test@github.com commit -m Commit Message --author=A Single Test <single@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
+}
+

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -273,3 +273,38 @@ main() {
 
 }
 
+@test "git-push-options-are-applied" {
+
+    INPUT_PUSH_OPTIONS="--force"
+
+    touch "${test_repository}"/new-file-{1,2,3}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt M new-file-3.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout master"
+    shellmock_expect git --type partial --match "add ."
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push --set-upstream origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+
+    [ "${lines[8]}" = "INPUT_PUSH_OPTIONS: --force" ]
+    [ "${lines[9]}" = "::debug::Apply push options --force" ]
+    [ "${lines[10]}" = "::debug::Push commit to remote branch master" ]
+
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout master" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags --force" ]
+
+}
+

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -33,9 +33,16 @@ setup() {
     export INPUT_TAGGING_MESSAGE=""
     export INPUT_PUSH_OPTIONS=""
     export INPUT_SKIP_DIRTY_CHECK=false
+
+    skipIfNot "$BATS_TEST_DESCRIPTION"
+
+    if [ -z "$TEST_FUNCTION" ]; then
+        shellmock_clean
+    fi
 }
 
 teardown() {
+
     if [ -z "$TEST_FUNCTION" ]; then
         shellmock_clean
     fi

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -351,3 +351,44 @@ main() {
 
 }
 
+@test "can-work-with-empty-branch-name" {
+
+    INPUT_BRANCH=""
+
+    touch "${test_repository}"/new-file-{1,2,3}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt M new-file-3.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout"
+    shellmock_expect git --type partial --match "add ."
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+
+    [ "${lines[0]}" = "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}" ]
+    [ "${lines[1]}" = "::set-output name=changes_detected::true" ]
+    [ "${lines[2]}" = "INPUT_BRANCH value: " ]
+    [ "${lines[3]}" = "INPUT_FILE_PATTERN: ." ]
+    [ "${lines[4]}" = "INPUT_COMMIT_OPTIONS: " ]
+    [ "${lines[5]}" = "::debug::Apply commit options " ]
+    [ "${lines[6]}" = "INPUT_TAGGING_MESSAGE: " ]
+    [ "${lines[7]}" = "No tagging message supplied. No tag will be added." ]
+    [ "${lines[8]}" = "INPUT_PUSH_OPTIONS: " ]
+    [ "${lines[9]}" = "::debug::Apply push options " ]
+    [ "${lines[10]}" = "::debug::git push origin" ]
+
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub push origin" ]
+}

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -58,39 +58,45 @@ main() {
     [ "${lines[2]}" = "Working tree clean. Nothing to commit." ]
 }
 
-# TODO: Fix Issue where changes in git repo are not detected
-# @test "commit-changed-files-and-push-to-remote" {
+@test "commit-changed-files-and-push-to-remote" {
 
-#     touch "${test_repository}"/new-file-{1,2,3}.txt
+    touch "${test_repository}"/new-file-{1,2,3}.txt
 
-#     shellmock_expect git --type partial --match "status"
-#     shellmock_expect git --type partial --match "checkout"
-#     shellmock_expect git --type partial --match "add"
-#     shellmock_expect git --type partial --match '-c'
-#     shellmock_expect git --type partial --match 'push origin'
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt M new-file-3.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout master"
+    shellmock_expect git --type partial --match "add ."
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push --set-upstream origin'
 
-#     run main
+    run main
 
-#     echo "$output"
+    echo "$output"
 
-#     # Success Exit Code
-#     [ "$status" = 0 ]
+    # Success Exit Code
+    [ "$status" = 0 ]
 
-#     [ "${lines[0]}" = "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}" ]
-#     [ "${lines[1]}" = "::set-output name=changes_detected::true" ]
-#     [ "${lines[2]}" = "INPUT_BRANCH value: master" ]
-#     [ "${lines[3]}" = "INPUT_FILE_PATTERN: ." ]
-#     [ "${lines[4]}" = "INPUT_COMMIT_OPTIONS: " ]
-#     [ "${lines[5]}" = "::debug::Apply commit options " ]
+    [ "${lines[0]}" = "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}" ]
+    [ "${lines[1]}" = "::set-output name=changes_detected::true" ]
+    [ "${lines[2]}" = "INPUT_BRANCH value: master" ]
+    [ "${lines[3]}" = "INPUT_FILE_PATTERN: ." ]
+    [ "${lines[4]}" = "INPUT_COMMIT_OPTIONS: " ]
+    [ "${lines[5]}" = "::debug::Apply commit options " ]
+    [ "${lines[6]}" = "INPUT_TAGGING_MESSAGE: " ]
+    [ "${lines[7]}" = "No tagging message supplied. No tag will be added." ]
+    [ "${lines[8]}" = "INPUT_PUSH_OPTIONS: " ]
+    [ "${lines[9]}" = "::debug::Apply push options " ]
+    [ "${lines[10]}" = "::debug::Push commit to remote branch master" ]
 
 
-#     shellmock_verify
-#     [ "${capture[0]}" = "git-stub status -s -- ." ]
-#     [ "${capture[1]}" = "git-stub checkout master" ]
-#     [ "${capture[2]}" = "git-stub add ." ]
-#     [ "${capture[3]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
-#     [ "${capture[4]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
-# }
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout master" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
+}
 
 
 @test "skip-dirty-on-clean-repo-failure" {

--- a/tests/commit.bats
+++ b/tests/commit.bats
@@ -105,7 +105,6 @@ main() {
     [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
 }
 
-
 @test "skip-dirty-on-clean-repo-failure" {
 
     INPUT_SKIP_DIRTY_CHECK=true


### PR DESCRIPTION
This PR builds upon #100 and expands the existing test suite written with [bats](https://github.com/sstephenson/bats) to cover every feature of git-auto-commit.

It's the first time I ever wrote tests for shell scripts, so apologies if the code isn't perfect. We're all learning here. 😅 

The tests are probably a bit too tightly coupled to the implementation. The tests are basically just validating the the right output is displayed and the right `git`-commands are called with the right options.

Despite the coupling, I think this is a good first version to get the confidence that changes don't break the Action. 
(It was honestly the biggest concern I always had when a PR has been opened)

---

Writing tests in bats can be quite confusing or overwhelming for new contributors. 
I plan to write a little guide on how to get started with `bats` and `shellmock` soon.
