### PR TITLE
Feature: Checkout Options

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,5 +14,6 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_MARKDOWN: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Add the following step at the end of your job, after other steps that might add 
     
     # Optional: Disable dirty check and always try to create a commit and push
     skip_dirty_check: true
+
+    # Optional: Allows you to update how the repo is checked out
+    checkout_options: '-q --force -b'
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: Push options (eg. --force)
     required: false
     default: ''
+  checkout_options:
+    description: Checkout options (eg. --branch)
+    required: false
+    default: ''
   skip_dirty_check:
     description: Skip the check if the git repository is dirty and always try to create a commit.
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,10 +29,11 @@ _main() {
 
 _switch_to_repository() {
     echo "INPUT_REPOSITORY value: $INPUT_REPOSITORY";
-    cd $INPUT_REPOSITORY;
+    cd "$INPUT_REPOSITORY";
 }
 
 _git_is_dirty() {
+    # shellcheck disable=SC2086
     [ -n "$(git status -s -- $INPUT_FILE_PATTERN)" ]
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,8 +42,11 @@ _switch_to_branch() {
     # Fetch remote to make sure that repo can be switched to the right branch.
     git fetch;
 
+    # shellcheck disable=SC2206
+    INPUT_CHECKOUT_OPTIONS_ARRAY=( $INPUT_CHECKOUT_OPTIONS );
+
     # Switch to branch from current Workflow run
-    git checkout "$INPUT_BRANCH" --;
+    git checkout ${INPUT_CHECKOUT_OPTIONS:+"${INPUT_CHECKOUT_OPTIONS_ARRAY[@]}"} "$INPUT_BRANCH" --;
 }
 
 _add_files() {

--- a/tests/git-auto-commit-mocked.bats
+++ b/tests/git-auto-commit-mocked.bats
@@ -32,6 +32,7 @@ setup() {
     export INPUT_COMMIT_AUTHOR="Test Suite <test@users.noreply.github.com>"
     export INPUT_TAGGING_MESSAGE=""
     export INPUT_PUSH_OPTIONS=""
+    export INPUT_CHECKOUT_OPTIONS=""
     export INPUT_SKIP_DIRTY_CHECK=false
 
     skipIfNot "$BATS_TEST_DESCRIPTION"
@@ -305,6 +306,39 @@ main() {
     [ "${capture[3]}" = "git-stub add ." ]
     [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
     [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags --force" ]
+
+}
+
+@test "git-checkout-options-are-applied" {
+
+    INPUT_CHECKOUT_OPTIONS="-b --progress"
+
+    touch "${test_repository}"/new-file-{1,2,3}.txt
+
+    shellmock_expect git --type partial --output " M new-file-1.txt M new-file-2.txt M new-file-3.txt" --match "status"
+    shellmock_expect git --type exact --match "fetch"
+    shellmock_expect git --type exact --match "checkout -b --progress master --"
+    shellmock_expect git --type partial --match "add ."
+    shellmock_expect git --type partial --match '-c'
+    shellmock_expect git --type partial --match 'push --set-upstream origin'
+
+    run main
+
+    echo "$output"
+
+    # Success Exit Code
+    [ "$status" = 0 ]
+
+    [ "${lines[10]}" = "::debug::Push commit to remote branch master" ]
+
+
+    shellmock_verify
+    [ "${capture[0]}" = "git-stub status -s -- ." ]
+    [ "${capture[1]}" = "git-stub fetch" ]
+    [ "${capture[2]}" = "git-stub checkout -b --progress master --" ]
+    [ "${capture[3]}" = "git-stub add ." ]
+    [ "${capture[4]}" = "git-stub -c user.name=Test Suite -c user.email=test@github.com commit -m Commit Message --author=Test Suite <test@users.noreply.github.com>" ]
+    [ "${capture[5]}" = "git-stub push --set-upstream origin HEAD:master --tags" ]
 
 }
 


### PR DESCRIPTION
In order to write a better test suite which doesn't mock `git`, I need a bit more control how the scripts switches to a branch.
This PR adds a simple `checkout_options`-input to the script; smilar to `push_options` and `commit_options`.