### PR TITLE
Set --depth on git-fetch and make call to git-fetch optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ This is a more extended example with all possible options.
     push_options: '--force'
     
     # Optional: Disable dirty check and always try to create a commit and push
-    skip_dirty_check: true
+    skip_dirty_check: true    
+    
+    # Optional: Skip internal call to `git fetch`
+    skip_fetch: true
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: Skip the check if the git repository is dirty and always try to create a commit.
     required: false
     default: false
+  skip_fetch:
+    description: Skip the call to git-fetch.
+    required: false
+    default: false
 
 outputs:
   changes_detected:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,12 @@ _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Fetch remote to make sure that repo can be switched to the right branch.
-    git fetch --depth=3;
+
+    if "$INPUT_SKIP_FETCH"; then
+        echo "::debug::git-fetch has not been executed";
+    else
+        git fetch --depth=3;
+    fi
 
     # Switch to branch from current Workflow run
     # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Fetch remote to make sure that repo can be switched to the right branch.
-    git fetch;
+    git fetch --depth=3;
 
     # Switch to branch from current Workflow run
     # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ _switch_to_branch() {
     if "$INPUT_SKIP_FETCH"; then
         echo "::debug::git-fetch has not been executed";
     else
-        git fetch --depth=3;
+        git fetch --depth=1;
     fi
 
     # Switch to branch from current Workflow run

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -21,6 +21,7 @@ setup() {
     export INPUT_TAGGING_MESSAGE=""
     export INPUT_PUSH_OPTIONS=""
     export INPUT_SKIP_DIRTY_CHECK=false
+    export INPUT_SKIP_FETCH=false
 
     # Configure Git
     if [[ -z $(git config user.name) ]]; then
@@ -296,4 +297,17 @@ git_auto_commit() {
     # Assert tag v2.0.0 has been pushed to remote
     run git ls-remote --tags --refs
     assert_output --partial refs/tags/v2.0.0
+}
+
+@test "If SKIP_FETCH is true git-fetch will not be called" {
+
+    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
+
+    INPUT_SKIP_FETCH=true
+
+    run git_auto_commit
+
+    assert_success
+
+    assert_line "::debug::git-fetch has not been executed"
 }


### PR DESCRIPTION
In this PR we're adding a new `skip_fetch` input option to disable the call to `git-fetch`. As reported in #130, calling `git-fetch` can have a negative impact on the performance of the Action in huge git repositories.

In addition, we added the [`--depth` argument](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---depthltdepthgt) to `git-fetch` to not fetch the entire history of the repo, but only the last 3 commits.


---

Sidenote: The call to `git-fetch` has been added in #108 in relation to a problem reported in #106 with branch names like `refactor/name`. The `/` previously created problems. 
By calling `git fetch` we've seemed to fix the error 🤷  Now that we have a test suite, it would probably make sense to switch to the proposed solution of using `git switch` (Will work on this in a separate PR)