### PR TITLE
Push Tags along with Commits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,7 +104,7 @@ _push_to_github() {
         if [ -n "$INPUT_TAGGING_MESSAGE" ]
         then
             echo "::debug::git push origin --tags";
-            git push origin --tags ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
+            git push origin --follow-tags --atomic ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
         else
             echo "::debug::git push origin";
             git push origin ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
@@ -112,7 +112,7 @@ _push_to_github() {
 
     else
         echo "::debug::Push commit to remote branch $INPUT_BRANCH";
-        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --tags ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
+        git push --set-upstream origin "HEAD:$INPUT_BRANCH" --follow-tags --atomic ${INPUT_PUSH_OPTIONS:+"${INPUT_PUSH_OPTIONS_ARRAY[@]}"};
     fi
 }
 


### PR DESCRIPTION
Refs #145 

By using —follow-tags we push all annotated tags alongside the commit to the remote repository.
In addition, we’re using —atomic. This ensures that all refs are updated.

- https://github.blog/2015-04-30-git-2-4-atomic-pushes-push-to-deploy-and-more/#atomic-pushes
- https://stackoverflow.com/a/3745250
- https://therightstuff.medium.com/the-rights-and-wrongs-of-git-push-with-tags-998667eaed8f