### PR TITLE
Add "disable_globbing" option to prevent shell from expanding filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ This is a more extended example with all possible options.
     skip_dirty_check: true    
     
     # Optional: Skip internal call to `git fetch`
-    skip_fetch: true
+    skip_fetch: true    
+    
+    # Optional: Prevents the shell from expanding filenames. Details: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
+    disable_globbing: true
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ inputs:
     description: Skip the call to git-fetch.
     required: false
     default: false
+  disable_globbing:
+    description: Stop the shell from expanding filenames (https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html)
+    default: false
 
 outputs:
   changes_detected:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 set -eu
-set -o noglob;
+
+if "$INPUT_DISABLE_GLOBBING"; then
+    set -o noglob;
+fi
 
 _main() {
     _switch_to_repository

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+set -o noglob;
 
 _main() {
     _switch_to_repository

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -22,6 +22,7 @@ setup() {
     export INPUT_PUSH_OPTIONS=""
     export INPUT_SKIP_DIRTY_CHECK=false
     export INPUT_SKIP_FETCH=false
+    export INPUT_DISABLE_GLOBBING=false
 
     # Configure Git
     if [[ -z $(git config user.name) ]]; then
@@ -422,6 +423,7 @@ git_auto_commit() {
     # ---
 
     INPUT_FILE_PATTERN="*.py"
+    INPUT_DISABLE_GLOBBING=true
 
     run git_auto_commit
 

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -402,7 +402,7 @@ git_auto_commit() {
     assert_equal $current_sha $remote_sha
 }
 
-@test "It does not expand wildcard glob when using INPUT_PATTERN in git-status and git-add" {
+@test "It does not expand wildcard glob when using INPUT_PATTERN and INPUT_DISABLE_GLOBBING in git-status and git-add" {
 
     # Create additional files in a nested directory structure
     echo "Create Additional files";
@@ -432,7 +432,7 @@ git_auto_commit() {
     assert_line "INPUT_FILE_PATTERN: *.py"
     assert_line "::debug::Push commit to remote branch master"
 
-    # Assert that py files have not been added.
+    # Assert that the updated py file has been commited.
     run git status
     refute_output --partial 'nested/new-file-b.py'
 }


### PR DESCRIPTION
Refs #153.

---

This PR adds a new `disable_globbing` option to the Action. This will prevent the shell from expanding filenames.
You can find more details about globbing in bash here:

- https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
- https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html (`-f`)


## Why
As reported in #153, in certain scenarios the Action fails to commit changed files. A test has been added to cover this edge case in https://github.com/stefanzweifel/git-auto-commit-action/commit/e610a5104baa0b55fd8b51e0736cf0a938799589.

My first instinct was to disable globbing globally for all executions. But after reading [more](https://stackoverflow.com/a/12225280) about `set -o noglob` I've decided to hide this feature behind a new option.

My gut tells me, that disabling globbing for all would lead just to more problems. 🤷 

## Bash Script for local testing

I've used the follwing shell script to test the in #153 reported edge case.

```bash
#!/bin/bash

rm -rf issue-153-example;
mkdir issue-153-example;
cd issue-153-example;

git init > /dev/null;

mkdir package;

touch package/module.py;
touch setup.py;

git add .;
git commit -m "Init" > /dev/null;


echo "test" > package/module.py;

# Enable/Disable this line to see the effect.
set -o noglob

git status -s -- *.py;
```