### PR TITLE
Add options for git add/status commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,14 @@ inputs:
     description: Commit options (eg. --no-verify)
     required: false
     default: ''
+  add_options:
+    description: Add options (eg. -u)
+    required: false
+    default: ''
+  status_options:
+    description: Status options (eg. --untracked-files=no)
+    required: false
+    default: ''
   file_pattern:
     description: File pattern used for `git add`. For example `src/\*.js`
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,8 +37,11 @@ _switch_to_repository() {
 }
 
 _git_is_dirty() {
+    echo "INPUT_STATUS_OPTIONS: ${INPUT_STATUS_OPTIONS}";
+    echo "::debug::Apply status options ${INPUT_STATUS_OPTIONS}";
+
     # shellcheck disable=SC2086
-    [ -n "$(git status -s -- $INPUT_FILE_PATTERN)" ]
+    [ -n "$(git status -s $INPUT_STATUS_OPTIONS -- $INPUT_FILE_PATTERN)" ]
 }
 
 _switch_to_branch() {
@@ -58,10 +61,13 @@ _switch_to_branch() {
 }
 
 _add_files() {
+    echo "INPUT_ADD_OPTIONS: ${INPUT_ADD_OPTIONS}";
+    echo "::debug::Apply add options ${INPUT_ADD_OPTIONS}";
+
     echo "INPUT_FILE_PATTERN: ${INPUT_FILE_PATTERN}";
 
     # shellcheck disable=SC2086
-    git add ${INPUT_FILE_PATTERN};
+    git add ${INPUT_ADD_OPTIONS} ${INPUT_FILE_PATTERN};
 }
 
 _local_commit() {


### PR DESCRIPTION
Adds options for git add/status commands.

---

This allows us to set the options required to only commit tracked files.
```
    - uses: stefanzweifel/git-auto-commit-action@v4
      with:
        status_options: '--untracked-files=no'
        add_options: '-u'
        file_pattern: ''
```