### PR TITLE
Update Shebang to point to /bin/sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const exec = (cmd, args=[]) => new Promise((resolve, reject) => {
 });
 
 const main = async () => {
-    await exec('bash', [path.join(__dirname, './entrypoint.sh')]);
+    await exec('sh', [path.join(__dirname, './entrypoint.sh')]);
 };
 
 main().catch(err => {


### PR DESCRIPTION
Update shebang of `entrypoint.sh` to use `/bin/sh` instead of `/bin/bash`. 
This change allows users to use the Action in different environments (eg. when they use  an `alpine`-container for a job)

Refs #166.