### PR TITLE
Output hash of created commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Checkout [`action.yml`](https://github.com/stefanzweifel/git-auto-commit-action/
 You can use these outputs to trigger other Actions in your Workflow run based on the result of `git-auto-commit-action`.
 
 - `changes_detected`: Returns either "true" or "false" if the repository was dirty and files have changed.
+- `commit_hash`: Returns the full hash of the commit if one was created.
 
 ### Example
 

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,8 @@ inputs:
 outputs:
   changes_detected:
     description: Value is "true", if the repository was dirty and file changes have been detected. Value is "false", if no changes have been detected.
+  commit_hash:
+    description: Full hash of the created commit. Only present if the "changes_detected" output is "true".
 
 runs:
   using: 'node12'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,8 @@ _local_commit() {
         commit -m "$INPUT_COMMIT_MESSAGE" \
         --author="$INPUT_COMMIT_AUTHOR" \
         ${INPUT_COMMIT_OPTIONS:+"${INPUT_COMMIT_OPTIONS_ARRAY[@]}"};
+
+    echo "::set-output name=commit_hash::$(git rev-parse HEAD)";
 }
 
 _tag_commit() {

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -86,6 +86,7 @@ git_auto_commit() {
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
     assert_line "::set-output name=changes_detected::true"
+    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
     assert_line "INPUT_BRANCH value: master"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -106,6 +107,7 @@ git_auto_commit() {
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
     assert_line "::set-output name=changes_detected::true"
+    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
     assert_line "INPUT_BRANCH value: master"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -128,6 +130,7 @@ git_auto_commit() {
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
     assert_line "::set-output name=changes_detected::false"
+    refute_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
     assert_line "Working tree clean. Nothing to commit."
 }
 
@@ -138,6 +141,7 @@ git_auto_commit() {
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
     assert_line "::set-output name=changes_detected::false"
+    refute_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
     assert_line "Working tree clean. Nothing to commit."
 }
 
@@ -150,8 +154,7 @@ git_auto_commit() {
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
     assert_line "::set-output name=changes_detected::true"
-
-    assert_line "::set-output name=changes_detected::true"
+    refute_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
     assert_line "INPUT_BRANCH value: master"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "


### PR DESCRIPTION
Adds `commit_hash` output populated with the full commit hash where relevant.

Fixes #171