### PR TITLE
Run git-auto-commit, linter and tests checks on pull requests

### DIFF
--- a/.github/workflows/git-auto-commit.yml
+++ b/.github/workflows/git-auto-commit.yml
@@ -1,6 +1,10 @@
 name: git-auto-commit
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   git-auto-commit:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,5 +1,10 @@
 name: Lint Code Base
-on: push
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,10 +1,6 @@
 name: Lint Code Base
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: push
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: tests
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   tests:
@@ -14,4 +18,3 @@ jobs:
 
     - name: Run Tests
       run: yarn test
-


### PR DESCRIPTION
Update the on-event definitions for the  `git-auto-commit`, `linter` and `tests` workflows.

 - **run workflows on all pull requests**
The relevant workflows run only on `push` events. Triggering these workflows on `pull_request` event ensures that checks will run when pull request are opened. This allows contributions from forks to have checks run.
 - **restrict `on-push` events to only pushes into master**
 Currently these workflows are triggered by `push` events to any branch. Since changes should only be introduced to `master` via pull requests, triggering these workflows on all `push` events seems unnecessary.

Summary:
- workflow runs on pull requests ensure checks are run before code reaches master
- workflow runs on pushes to master act as a backup to verify that the post-merge push to master didn't introduce any breakage

