### PR TITLE
Add `skip_checkout` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The following is an extended example with all possible options available for thi
     # Optional. Skip internal call to `git fetch`
     skip_fetch: true    
     
+    # Optional. Skip internal call to `git checkout`
+    skip_checkout: true
+
     # Optional. Prevents the shell from expanding filenames. 
     # Details: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
     disable_globbing: true

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: Skip the call to git-fetch.
     required: false
     default: false
+  skip_checkout:
+    description: Skip the call to git-checkout.
+    required: false
+    default: false
   disable_globbing:
     description: Stop the shell from expanding filenames (https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html)
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,9 +55,13 @@ _switch_to_branch() {
         git fetch --depth=1;
     fi
 
-    # Switch to branch from current Workflow run
-    # shellcheck disable=SC2086
-    git checkout $INPUT_BRANCH;
+    if "$INPUT_SKIP_CHECKOUT"; then
+        echo "::debug::git-checkout has not been executed";
+    else
+        # Switch to branch from current Workflow run
+        # shellcheck disable=SC2086
+        git checkout $INPUT_BRANCH;
+    fi
 }
 
 _add_files() {

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -24,6 +24,7 @@ setup() {
     export INPUT_PUSH_OPTIONS=""
     export INPUT_SKIP_DIRTY_CHECK=false
     export INPUT_SKIP_FETCH=false
+    export INPUT_SKIP_CHECKOUT=false
     export INPUT_DISABLE_GLOBBING=false
 
     # Configure Git
@@ -379,6 +380,19 @@ git_auto_commit() {
     assert_success
 
     assert_line "::debug::git-fetch has not been executed"
+}
+
+@test "If SKIP_CHECKOUT is true git-checkout will not be called" {
+
+    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
+
+    INPUT_SKIP_CHECKOUT=true
+
+    run git_auto_commit
+
+    assert_success
+
+    assert_line "::debug::git-checkout has not been executed"
 }
 
 @test "It pushes generated commit and tag to remote and actually updates the commit shas" {


### PR DESCRIPTION
Add an option to skip `git checkout` when a branch is provided. This makes it possible to mimic the following flow:

```bash
git checkout initial-branch
git add $stuff
git commit -m $message
git push -f origin HEAD:new-branch
```