### PR TITLE
Add missing links in the CHANGELOG

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 ame-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE ([#$NUMBER](https://github.com/stefanzweifel/git-auto-commit-action/pull/$NUMBER)) [@$AUTHOR](https://github.com/@$AUTHOR)'
 template: |
-  # What's Changed
   $CHANGES
 categories:
   - title: Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,38 +13,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Changed
 
-- Change Commit User Name from "GitHub Actions" to "github-actions[bot]" (#213) @jooola
-- Change Commit User Email from "actions@github.com" to "github-actions[bot]@users.noreply.github.com" (#213) @jooola
+- Change Commit User Name from "GitHub Actions" to "github-actions[bot]" ([#213](https://github.com/stefanzweifel/git-auto-commit-action/pull/213)) @jooola
+- Change Commit User Email from "actions@github.com" to "github-actions[bot]@users.noreply.github.com" ([#213](https://github.com/stefanzweifel/git-auto-commit-action/pull/213)) @jooola
 
 ## Fixed
 
-- Update doc link to GITHUB_TOKEN not triggering new workflow runs (#206) @gapple
+- Update doc link to GITHUB_TOKEN not triggering new workflow runs ([#206](https://github.com/stefanzweifel/git-auto-commit-action/pull/206)) @gapple
 
 ## [v4.14.0](https://github.com/stefanzweifel/git-auto-commit-action/compare/v4.13.1...v4.14.0) - 2022-03-18
 
 ## Added
 
-- Add `create_branch` option to force create a new branch (#203) @stefanzweifel
+- Add `create_branch` option to force create a new branch ([#203](https://github.com/stefanzweifel/git-auto-commit-action/pull/203)) @stefanzweifel
 
 ## Fixed
 
-- README.md: Updates hyperlink to GH docs (#200) @funkyfuture
+- README.md: Updates hyperlink to GH docs ([#200](https://github.com/stefanzweifel/git-auto-commit-action/pull/200)) @funkyfuture
 
 ## [v4.13.1](https://github.com/stefanzweifel/git-auto-commit-action/compare/v4.13.0...v4.13.1) - 2022-01-13
 
 ## Fixed
 
-- Properly disambiguate between branch or file checkout (#199) @kenodegard
+- Properly disambiguate between branch or file checkout ([#199](https://github.com/stefanzweifel/git-auto-commit-action/pull/199)) @kenodegard
 
 ## [v4.13.0](https://github.com/stefanzweifel/git-auto-commit-action/compare/v4.12.0...v4.13.0) - 2022-01-10
 
 ## Added
 
-- Add `skip_checkout` option (#197) @cmbuckley
+- Add `skip_checkout` option ([#197](https://github.com/stefanzweifel/git-auto-commit-action/pull/197)) @cmbuckley
 
 ## Changed
 
-- Add note on minimum permissions to the docs (#180) @ericcornelissen
+- Add note on minimum permissions to the docs ([#180](https://github.com/stefanzweifel/git-auto-commit-action/pull/180)) @ericcornelissen
 
 ## [v4.12.0](https://github.com/stefanzweifel/git-auto-commit-action/compare/v4.11.0...v4.12.0) - 2021-09-10
 


### PR DESCRIPTION
Add missing links for Pull Requests to the CHANGELOG. I considered adding links for the GitHub users as well, but opted not to as there's no precedence for that.

Also, I wasn't sure whether or not to include this change in the CHANGELOG. It doesn't seem necessary to me, but I'm happy to add it if that's preferred :slightly_smiling_face: 