### PR TITLE
Replace set-output usage with GITHUB_OUTPUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ The steps in your workflow might look like this:
 - name: Get last commit message
   id: last-commit-message
   run: |
-    echo "::set-output name=msg::$(git log -1 --pretty=%s)"
+    echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
 - uses: stefanzweifel/git-auto-commit-action@v4
   with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ _main() {
 
     if _git_is_dirty || "$INPUT_SKIP_DIRTY_CHECK"; then
 
-        echo "::set-output name=changes_detected::true";
+        echo "changes_detected=true" >> $GITHUB_OUTPUT;
 
         _switch_to_branch
 
@@ -24,7 +24,7 @@ _main() {
         _push_to_github
     else
 
-        echo "::set-output name=changes_detected::false";
+        echo "changes_detected=false" >> $GITHUB_OUTPUT;
 
         echo "Working tree clean. Nothing to commit.";
     fi
@@ -101,7 +101,7 @@ _local_commit() {
         --author="$INPUT_COMMIT_AUTHOR" \
         ${INPUT_COMMIT_OPTIONS:+"${INPUT_COMMIT_OPTIONS_ARRAY[@]}"};
 
-    echo "::set-output name=commit_hash::$(git rev-parse HEAD)";
+    echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT;
 }
 
 _tag_commit() {

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -87,8 +87,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
-    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
+    assert_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: master"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -108,8 +108,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
-    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
+    assert_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: master"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -131,8 +131,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::false"
-    refute_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=false" >> $GITHUB_OUTPUT'
+    refute_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "Working tree clean. Nothing to commit."
 }
 
@@ -142,8 +142,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::false"
-    refute_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=false" >> $GITHUB_OUTPUT'
+    refute_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "Working tree clean. Nothing to commit."
 }
 
@@ -155,8 +155,8 @@ git_auto_commit() {
     assert_failure
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
-    refute_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
+    refute_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: master"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -504,7 +504,7 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::false"
+    assert_line '"changes_detected=false" >> $GITHUB_OUTPUT'
 
     run git status
     assert_output --partial 'nothing to commit, working tree clean'
@@ -532,7 +532,7 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
     assert_line "::debug::Push commit to remote branch dev"
 }
 
@@ -553,7 +553,7 @@ git_auto_commit() {
     assert_failure
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: not-existend-branch"
     assert_line "fatal: invalid reference: not-existend-branch"
 
@@ -581,8 +581,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
-    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
+    assert_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: not-existend-branch"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -621,8 +621,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
-    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
+    assert_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: not-existend-remote-branch"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
@@ -675,8 +675,8 @@ git_auto_commit() {
     assert_success
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "::set-output name=changes_detected::true"
-    assert_line -e "::set-output name=commit_hash::[0-9a-f]{40}$"
+    assert_line '"changes_detected=true" >> $GITHUB_OUTPUT'
+    assert_line -e '"commit_hash=[0-9a-f]{40}$" >> $GITHUB_OUTPUT'
     assert_line "INPUT_BRANCH value: existing-remote-branch"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,13 +4,13 @@
 
 bats-assert@ztombol/bats-assert:
   version "0.3.0"
-  resolved "git+ssh://git@github.com/ztombol/bats-assert.git#9f88b4207da750093baabc4e3f41bf68f0dd3630"
+  resolved "https://codeload.github.com/ztombol/bats-assert/tar.gz/9f88b4207da750093baabc4e3f41bf68f0dd3630"
 
 bats-support@ztombol/bats-support:
   version "0.3.0"
-  resolved "git+ssh://git@github.com/ztombol/bats-support.git#004e707638eedd62e0481e8cdc9223ad471f12ee"
+  resolved "https://codeload.github.com/ztombol/bats-support/tar.gz/004e707638eedd62e0481e8cdc9223ad471f12ee"
 
 bats@^1.1.0:
   version "1.7.0"
-  resolved "https://registry.npmjs.org/bats/-/bats-1.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/bats/-/bats-1.7.0.tgz#caae958b1d211eda6b1322ac7792515de40165a2"
   integrity sha512-pt5zjJQUB4+JI8Si+z/IAWc8yhMyhdZs6IXMCKgzF768dUIyW5xyBstWtDI5uGSa80v7UQOhh+w0GA4p4+01Bg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,13 +4,13 @@
 
 bats-assert@ztombol/bats-assert:
   version "0.3.0"
-  resolved "https://codeload.github.com/ztombol/bats-assert/tar.gz/9f88b4207da750093baabc4e3f41bf68f0dd3630"
+  resolved "git+ssh://git@github.com/ztombol/bats-assert.git#9f88b4207da750093baabc4e3f41bf68f0dd3630"
 
 bats-support@ztombol/bats-support:
   version "0.3.0"
-  resolved "https://codeload.github.com/ztombol/bats-support/tar.gz/004e707638eedd62e0481e8cdc9223ad471f12ee"
+  resolved "git+ssh://git@github.com/ztombol/bats-support.git#004e707638eedd62e0481e8cdc9223ad471f12ee"
 
 bats@^1.1.0:
   version "1.7.0"
-  resolved "https://registry.yarnpkg.com/bats/-/bats-1.7.0.tgz#caae958b1d211eda6b1322ac7792515de40165a2"
+  resolved "https://registry.npmjs.org/bats/-/bats-1.7.0.tgz"
   integrity sha512-pt5zjJQUB4+JI8Si+z/IAWc8yhMyhdZs6IXMCKgzF768dUIyW5xyBstWtDI5uGSa80v7UQOhh+w0GA4p4+01Bg==


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and the recommended migration.

Should fix #250.

This should prevent warnings (and in the future errors) appearing in GitHub summaries. 

Generated using `fastmod`
```shell
; fastmod 'echo "::set-output name=([[:alnum:]\-_]+)::(.*)"' 'echo "${1}=${2}" >> $$GITHUB_OUTPUT'
; fastmod 'assert_line "::set-output name=([[:alnum:]\-_]+)::(.*)"' 'assert_line \'"${1}=${2}" >> $$GITHUB_OUTPUT\''
; fastmod 'assert_line -e "::set-output name=([[:alnum:]\-_]+)::(.*)"' 'assert_line -e \'"${1}=${2}" >> $$GITHUB_OUTPUT\''
; fastmod 'refute_line "::set-output name=([[:alnum:]\-_]+)::(.*)"' 'refute_line \'"${1}=${2}" >> $$GITHUB_OUTPUT\''
```

Before
![CleanShot 2022-10-20 at 21 15 11@2x](https://user-images.githubusercontent.com/1282845/197088662-e9cb626e-ff49-4513-8829-719b93325cb2.png)

After
![CleanShot 2022-10-20 at 21 15 52@2x](https://user-images.githubusercontent.com/1282845/197088671-942c60e4-428a-4af9-a98d-8a82c136f6cd.png)
