### PR TITLE
Use deprecated set-output syntax if GITHUB_OUTPUT environment is not available

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,13 @@ _main() {
 
     if _git_is_dirty || "$INPUT_SKIP_DIRTY_CHECK"; then
 
-        echo "changes_detected=true" >> $GITHUB_OUTPUT;
+        # Check if $GITHUB_OUTPUT is available
+        # (Feature detection will be removed in late December 2022)
+        if [ -z ${GITHUB_OUTPUT+x} ]; then
+            echo "::set-output name=changes_detected::true";
+        else
+            echo "changes_detected=true" >> $GITHUB_OUTPUT;
+        fi
 
         _switch_to_branch
 
@@ -24,7 +30,13 @@ _main() {
         _push_to_github
     else
 
-        echo "changes_detected=false" >> $GITHUB_OUTPUT;
+        # Check if $GITHUB_OUTPUT is available
+        # (Feature detection will be removed in late December 2022)
+        if [ -z ${GITHUB_OUTPUT+x} ]; then
+            echo "::set-output name=changes_detected::false";
+        else
+            echo "changes_detected=false" >> $GITHUB_OUTPUT;
+        fi
 
         echo "Working tree clean. Nothing to commit.";
     fi
@@ -101,7 +113,14 @@ _local_commit() {
         --author="$INPUT_COMMIT_AUTHOR" \
         ${INPUT_COMMIT_OPTIONS:+"${INPUT_COMMIT_OPTIONS_ARRAY[@]}"};
 
-    echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT;
+
+    # Check if $GITHUB_OUTPUT is available
+    # (Feature detection will be removed in late December 2022)
+    if [ -z ${GITHUB_OUTPUT+x} ]; then
+        echo "::set-output name=commit_hash::$(git rev-parse HEAD)";
+    else
+        echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT;
+    fi
 }
 
 _tag_commit() {


### PR DESCRIPTION
This PR solves the issue reported in #254, where the Action fails in environments not yet updated to the latest GitHub Actions runner where `$GITHUB_OUTPUT` is availbale.

The PR changes the Action to first check if `$GITHUB_OUTPUT` is available. If available the new syntax is used.
If `$GITHUB_OUTPUT` is missing, the now deprecated syntax `set-output` is used.

`set-output` is supported by GitHub until June 2023. 
I plan to remove this fallback code in late December 2022 with the hope, that most runners of GitHub Enterprise have been updated by then.