### PR TITLE
Update default email address of github-actions[bot]

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following is an extended example with all available options.
 
     # Optional commit user and author settings
     commit_user_name: My GitHub Actions Bot # defaults to "github-actions[bot]"
-    commit_user_email: my-github-actions-bot@example.org # defaults to "github-actions[bot]@users.noreply.github.com"
+    commit_user_email: my-github-actions-bot@example.org # defaults to "41898282+github-actions[bot]@users.noreply.github.com"
     commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
 
     # Optional. Tag name being created in the local repository and 

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   commit_user_email:
     description: Email address used for the commit user
     required: false
-    default: github-actions[bot]@users.noreply.github.com
+    default: 41898282+github-actions[bot]@users.noreply.github.com
   commit_author:
     description: Value used for the commit author. Defaults to the username of whoever triggered this workflow run.
     required: false


### PR DESCRIPTION
GitHub uses the [new email format](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) by default at commits when the `github-actions[bot]` is being used. This should bring it inline with that.