### PR TITLE
Fix "nothing to commit" error with LF/CRLF changes #241

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,11 +25,24 @@ _main() {
 
         _add_files
 
-        _local_commit
+        if [ -n "$(git diff --staged)" ]; then
+            _local_commit
 
-        _tag_commit
+            _tag_commit
 
-        _push_to_github
+            _push_to_github
+        else
+
+            # Check if $GITHUB_OUTPUT is available
+            # (Feature detection will be removed in late December 2022)
+            if [ -z ${GITHUB_OUTPUT+x} ]; then
+                echo "::set-output name=changes_detected::false";
+            else
+                echo "changes_detected=false" >> $GITHUB_OUTPUT;
+            fi
+
+            echo "Working tree clean. Nothing to commit.";
+        fi
     else
 
         # Check if $GITHUB_OUTPUT is available

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ _main() {
 
         _add_files
 
+        # Check dirty state of repo again using git-diff.
+        # (git-diff detects beter if CRLF of files changes and does NOT
+        # proceed, if only CRLF changes are detected. See #241 and #265
+        # for more details.)
         if [ -n "$(git diff --staged)" ] || "$INPUT_SKIP_DIRTY_CHECK"; then
             _local_commit
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ _main() {
 
         _add_files
 
-        if [ -n "$(git diff --staged)" ]; then
+        if [ -n "$(git diff --staged)" ] || "$INPUT_SKIP_DIRTY_CHECK"; then
             _local_commit
 
             _tag_commit

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -974,7 +974,7 @@ cat_github_output() {
     assert_line --partial "another-subdirectory/new-file-3.txt"
 }
 
-@test "fails to detect crlf change in files and does not detect change or commit changes" {
+@test "detects if crlf in files change and does not create commit" {
     # Set autocrlf to true
     cd "${FAKE_LOCAL_REPOSITORY}"
     git config core.autocrlf true
@@ -996,6 +996,13 @@ cat_github_output() {
     run git_auto_commit
 
     assert_success
+
+    refute_line --partial "2 files changed, 2 insertions(+), 2 deletions(-)"
+    assert_line --partial "warning: in the working copy of 'new-file-2.txt', LF will be replaced by CRLF the next time Git touches it"
+
+    assert_line --partial "Working tree clean. Nothing to commit."
+    assert_line --partial "new-file-2.txt"
+    assert_line --partial "new-file-3.txt"
 
     # Changes are not detected
     run cat_github_output

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -982,15 +982,15 @@ cat_github_output() {
     assert_line "true"
 
     # Add more .txt files
-    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-2.txt
-    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-3.txt
+    echo -ne "crlf test1\r\n" > "${FAKE_LOCAL_REPOSITORY}"/new-file-2.txt
+    echo -ne "crlf test1\n" > "${FAKE_LOCAL_REPOSITORY}"/new-file-3.txt
 
     # Run git-auto-commit to add new files to repository
     run git_auto_commit
 
     # Change control characters in files
-    sed 's/^M$//' "${FAKE_LOCAL_REPOSITORY}"/new-file-2.txt
-    sed 's/$/^M/' "${FAKE_LOCAL_REPOSITORY}"/new-file-3.txt
+    echo -ne "crlf test1\n" > "${FAKE_LOCAL_REPOSITORY}"/new-file-2.txt
+    echo -ne "crlf test1\r\n" > "${FAKE_LOCAL_REPOSITORY}"/new-file-3.txt
 
     # Run git-auto-commit to commit the 2 changes files
     run git_auto_commit
@@ -998,10 +998,8 @@ cat_github_output() {
     assert_success
 
     # Changes are not detected
-    assert_line --partial "Working tree clean. Nothing to commit."
-
-    refute_line --partial "new-file-2.txt"
-    refute_line --partial "new-file-3.txt"
+    run cat_github_output
+    assert_line "changes_detected=false"
 }
 
 


### PR DESCRIPTION
Previously I tried to solve this by switching the order for `add` and `status`, which results in some side effects.
Here I tried to solve the issue by adding a `diff` check right before `commit` so other behaviors are not affected.
 
Note that the testcase for crlf in the original repo does not change line ending properly, so I also updated the test. The original action [fails](https://github.com/ZeroRin/git-auto-commit-action/actions/runs/3581237628) on this test while the modified version [passes](https://github.com/ZeroRin/git-auto-commit-action/actions/runs/3581287710) all the tests.

Related to #241.