### PR TITLE
Update node version to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ outputs:
     description: Full hash of the created commit. Only present if the "changes_detected" output is "true".
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 
 branding:


### PR DESCRIPTION
Node20 was added to Actions Runner on [v2.308.0](https://github.com/actions/runner/releases/tag/v2.308.0).
Node16 will be end of life on 11 Sep 2023.

This PR updates the default runtime to node20, rather than node16