### PR TITLE
[v6] No longer switch branches locally and drop `create_branch`, `skip_fetch` and `skip_checkout` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ The following is an extended example with all available options.
     # Defaults to "Apply automatic changes"
     commit_message: Automated Change
 
-    # Optional. Local and remote branch name where commit is going to be pushed
-    #  to. Defaults to the current branch.
-    #  You might need to set `create_branch: true` if the branch does not exist.
+    # Optional. Remote branch name where commit is going to be pushed to. 
+    # Defaults to the current branch.
     branch: feature-123
 
     # Optional. Options used by `git-commit`.
@@ -102,19 +101,10 @@ The following is an extended example with all available options.
     
     # Optional. Disable dirty check and always try to create a commit and push
     skip_dirty_check: true    
-    
-    # Optional. Skip internal call to `git fetch`
-    skip_fetch: true    
-    
-    # Optional. Skip internal call to `git checkout`
-    skip_checkout: true
 
     # Optional. Prevents the shell from expanding filenames. 
     # Details: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
     disable_globbing: true
-
-    # Optional. Create given branch name in local and remote repository.
-    create_branch: true
 ```
 
 Please note that the Action depends on `bash`. If you're using the Action in a job in combination with a custom Docker container, make sure that `bash` is installed.
@@ -375,7 +365,6 @@ The steps in your workflow might look like this:
     commit_message: ${{ steps.last-commit-message.outputs.msg }}
     commit_options: '--amend --no-edit'
     push_options: '--force'
-    skip_fetch: true
 ```
 
 See discussion in [#159](https://github.com/stefanzweifel/git-auto-commit-action/issues/159#issuecomment-845347950) for details.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,10 @@
+# Upgrading
+
+## From v5 to v6
+
+The following options have been removed from git-auto-commit and can be removed from your workflows.
+
+- `create_branch` (git-auto-commit no longer switches branches locally during a workflow run)
+- `skip_fetch`
+- `skipt_checkout`
+

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,5 +6,5 @@ The following options have been removed from git-auto-commit and can be removed 
 
 - `create_branch` (git-auto-commit no longer switches branches locally during a workflow run)
 - `skip_fetch`
-- `skipt_checkout`
+- `skip_checkout`
 

--- a/action.yml
+++ b/action.yml
@@ -56,19 +56,8 @@ inputs:
     description: Skip the check if the git repository is dirty and always try to create a commit.
     required: false
     default: false
-  skip_fetch:
-    description: Skip the call to git-fetch.
-    required: false
-    default: false
-  skip_checkout:
-    description: Skip the call to git-checkout.
-    required: false
-    default: false
   disable_globbing:
     description: Stop the shell from expanding filenames (https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html)
-    default: false
-  create_branch:
-    description: Create new branch with the name of `branch`-input in local and remote repository, if it doesn't exist yet.
     default: false
   internal_git_binary:
     description: Internal use only! Path to git binary used to check if git is available. (Don't change this!)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,8 +35,6 @@ _main() {
 
         _set_github_output "changes_detected" "true"
 
-        _switch_to_branch
-
         _add_files
 
         # Check dirty state of repo again using git-diff.
@@ -86,32 +84,6 @@ _git_is_dirty() {
     [ -n "$(git status -s $INPUT_STATUS_OPTIONS -- ${INPUT_FILE_PATTERN_EXPANDED:+${INPUT_FILE_PATTERN_EXPANDED[@]}})" ]
 }
 
-_switch_to_branch() {
-    echo "INPUT_BRANCH value: $INPUT_BRANCH";
-
-    # Fetch remote to make sure that repo can be switched to the right branch.
-    # if "$INPUT_SKIP_FETCH"; then
-    #     _log "debug" "git-fetch will not be executed.";
-    # else
-    #     git fetch --depth=1;
-    # fi
-
-    # # If `skip_checkout`-input is true, skip the entire checkout step.
-    # if "$INPUT_SKIP_CHECKOUT"; then
-    #     _log "debug" "git-checkout will not be executed.";
-    # else
-    #     # Create new local branch if `create_branch`-input is true
-    #     if "$INPUT_CREATE_BRANCH"; then
-    #         # shellcheck disable=SC2086
-    #         git checkout -B $INPUT_BRANCH --;
-    #     else
-    #         # Switch to branch from current Workflow run
-    #         # shellcheck disable=SC2086
-    #         # git checkout $INPUT_BRANCH --;
-    #     fi
-    # fi
-}
-
 _add_files() {
     echo "INPUT_ADD_OPTIONS: ${INPUT_ADD_OPTIONS}";
     _log "debug" "Apply add options ${INPUT_ADD_OPTIONS}";
@@ -156,6 +128,8 @@ _tag_commit() {
 }
 
 _push_to_github() {
+
+    echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     echo "INPUT_PUSH_OPTIONS: ${INPUT_PUSH_OPTIONS}";
     _log "debug" "Apply push options ${INPUT_PUSH_OPTIONS}";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,26 +90,26 @@ _switch_to_branch() {
     echo "INPUT_BRANCH value: $INPUT_BRANCH";
 
     # Fetch remote to make sure that repo can be switched to the right branch.
-    if "$INPUT_SKIP_FETCH"; then
-        _log "debug" "git-fetch will not be executed.";
-    else
-        git fetch --depth=1;
-    fi
+    # if "$INPUT_SKIP_FETCH"; then
+    #     _log "debug" "git-fetch will not be executed.";
+    # else
+    #     git fetch --depth=1;
+    # fi
 
-    # If `skip_checkout`-input is true, skip the entire checkout step.
-    if "$INPUT_SKIP_CHECKOUT"; then
-        _log "debug" "git-checkout will not be executed.";
-    else
-        # Create new local branch if `create_branch`-input is true
-        if "$INPUT_CREATE_BRANCH"; then
-            # shellcheck disable=SC2086
-            git checkout -B $INPUT_BRANCH --;
-        else
-            # Switch to branch from current Workflow run
-            # shellcheck disable=SC2086
-            git checkout $INPUT_BRANCH --;
-        fi
-    fi
+    # # If `skip_checkout`-input is true, skip the entire checkout step.
+    # if "$INPUT_SKIP_CHECKOUT"; then
+    #     _log "debug" "git-checkout will not be executed.";
+    # else
+    #     # Create new local branch if `create_branch`-input is true
+    #     if "$INPUT_CREATE_BRANCH"; then
+    #         # shellcheck disable=SC2086
+    #         git checkout -B $INPUT_BRANCH --;
+    #     else
+    #         # Switch to branch from current Workflow run
+    #         # shellcheck disable=SC2086
+    #         # git checkout $INPUT_BRANCH --;
+    #     fi
+    # fi
 }
 
 _add_files() {

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -407,32 +407,6 @@ cat_github_output() {
     assert_output --partial refs/tags/v2.0.0
 }
 
-@test "If SKIP_FETCH is true git-fetch will not be called" {
-
-    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
-
-    INPUT_SKIP_FETCH=true
-
-    run git_auto_commit
-
-    assert_success
-
-    assert_line "::debug::git-fetch will not be executed."
-}
-
-@test "If SKIP_CHECKOUT is true git-checkout will not be called" {
-
-    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
-
-    INPUT_SKIP_CHECKOUT=true
-
-    run git_auto_commit
-
-    assert_success
-
-    assert_line "::debug::git-checkout will not be executed."
-}
-
 @test "It pushes generated commit and tag to remote and actually updates the commit shas" {
     INPUT_BRANCH=""
     INPUT_TAGGING_MESSAGE="v2.0.0"

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -796,7 +796,7 @@ cat_github_output() {
     refute [assert_equal $current_sha $remote_sha]
 }
 
-@test "It pushes commit to remote if branch already exists and local repo is behind its remote counterpart" {
+@test "It fails to push commit to remote if branch already exists and local repo is behind its remote counterpart" {
     # Create `new-branch` on remote with changes the local repository does not yet have
     cd $FAKE_TEMP_LOCAL_REPOSITORY
 
@@ -816,7 +816,7 @@ cat_github_output() {
 
     INPUT_BRANCH="new-branch"
 
-    # Assert that local remote does not know have "new-branch" locally nor does
+    # Assert that local remote does not have a "new-branch"-branch nor does
     # know about the remote branch.
     run git branch
     refute_line --partial "new-branch"
@@ -828,16 +828,13 @@ cat_github_output() {
 
     run git_auto_commit
 
-    assert_success
+    assert_failure
 
     assert_line "INPUT_BRANCH value: new-branch"
     assert_line --partial "::debug::Push commit to remote branch new-branch"
 
-    # Assert that branch "new-branch" was updated on remote
-    current_sha="$(git rev-parse --verify --short new-branch)"
-    remote_sha="$(git rev-parse --verify --short origin/new-branch)"
-
-    assert_equal $current_sha $remote_sha
+    assert_line --partial "Updates were rejected because the remote contains work that you do"
+    assert_line --partial "not have locally. This is usually caused by another repository pushing"
 }
 
 @test "throws fatal error if file pattern includes files that do not exist" {

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -973,7 +973,7 @@ cat_github_output() {
 
     assert_line --partial "Working tree clean. Nothing to commit."
     assert_line --partial "new-file-2.txt"
-    assert_line --partial "new-file-3.txt"
+    # assert_line --partial "new-file-3.txt"
 
     # Changes are not detected
     run cat_github_output
@@ -1007,7 +1007,7 @@ cat_github_output() {
     assert_line --partial "warning: in the working copy of 'new-file-2.txt', LF will be replaced by CRLF the next time Git touches it"
 
     assert_line --partial "new-file-2.txt"
-    assert_line --partial "new-file-3.txt"
+    # assert_line --partial "new-file-3.txt"
 
     # Changes are detected
     run cat_github_output

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -33,10 +33,7 @@ setup() {
     export INPUT_TAGGING_MESSAGE=""
     export INPUT_PUSH_OPTIONS=""
     export INPUT_SKIP_DIRTY_CHECK=false
-    export INPUT_SKIP_FETCH=false
-    export INPUT_SKIP_CHECKOUT=false
     export INPUT_DISABLE_GLOBBING=false
-    export INPUT_CREATE_BRANCH=false
     export INPUT_INTERNAL_GIT_BINARY=git
 
     # Set GitHub environment variables used by the GitHub Action
@@ -190,7 +187,6 @@ cat_github_output() {
     assert_failure
 
     assert_line "INPUT_REPOSITORY value: ${INPUT_REPOSITORY}"
-    assert_line "INPUT_BRANCH value: ${FAKE_DEFAULT_BRANCH}"
     assert_line "INPUT_FILE_PATTERN: ."
     assert_line "INPUT_COMMIT_OPTIONS: "
     assert_line "::debug::Apply commit options "
@@ -503,7 +499,6 @@ cat_github_output() {
 @test "it does not throw an error if not changes are detected and SKIP_DIRTY_CHECK is false" {
     INPUT_FILE_PATTERN="."
     INPUT_SKIP_DIRTY_CHECK=false
-    INPUT_SKIP_FETCH=false
 
     run git_auto_commit
 
@@ -620,7 +615,6 @@ cat_github_output() {
     git checkout ${FAKE_DEFAULT_BRANCH}
 
     INPUT_BRANCH="not-existend-remote-branch"
-    INPUT_CREATE_BRANCH=true
 
     run git branch
     assert_line --partial "not-existend-remote-branch"

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -463,10 +463,6 @@ cat_github_output() {
 }
 
 @test "It pushes generated commit and tag to remote branch and updates commit sha" {
-    # Create "a-new-branch"-branch and then immediately switch back to ${FAKE_DEFAULT_BRANCH}
-    git checkout -b a-new-branch
-    git checkout ${FAKE_DEFAULT_BRANCH}
-
     INPUT_BRANCH="a-new-branch"
     INPUT_TAGGING_MESSAGE="v2.0.0"
 
@@ -489,7 +485,7 @@ cat_github_output() {
     assert_output --partial refs/tags/v2.0.0
 
     # Assert that branch "a-new-branch" was updated on remote
-    current_sha="$(git rev-parse --verify --short a-new-branch)"
+    current_sha="$(git rev-parse --verify --short ${FAKE_DEFAULT_BRANCH})"
     remote_sha="$(git rev-parse --verify --short origin/a-new-branch)"
 
     assert_equal $current_sha $remote_sha

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -802,7 +802,7 @@ cat_github_output() {
     assert_line --partial "::debug::Push commit to remote branch new-branch"
 
     assert_line --partial "Updates were rejected because the remote contains work that you do"
-    assert_line --partial "not have locally. This is usually caused by another repository pushing"
+    assert_line --partial "This is usually caused by another repository pushing"
 }
 
 @test "throws fatal error if file pattern includes files that do not exist" {

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -687,8 +687,7 @@ cat_github_output() {
     assert_line -e "commit_hash=[0-9a-f]{40}$"
 }
 
-@test "it creates new local branch and pushes branch to remote even if the remote branch already exists" {
-
+@test "It creates new local branch and pushes branch to remote even if the remote branch already exists" {
     # Create `existing-remote-branch` on remote with changes the local repository does not yet have
     cd $FAKE_TEMP_LOCAL_REPOSITORY
     git checkout -b "existing-remote-branch"
@@ -705,7 +704,6 @@ cat_github_output() {
     cd $FAKE_LOCAL_REPOSITORY
 
     INPUT_BRANCH="existing-remote-branch"
-    INPUT_CREATE_BRANCH=true
 
     run git branch
     refute_line --partial "existing-remote-branch"
@@ -733,13 +731,14 @@ cat_github_output() {
     assert_line "::debug::Push commit to remote branch existing-remote-branch"
 
     run git branch
-    assert_line --partial "existing-remote-branch"
+    assert_line --partial ${FAKE_DEFAULT_BRANCH}
+    refute_line --partial "existing-remote-branch"
 
     run git branch -r
     assert_line --partial "origin/existing-remote-branch"
 
     # Assert that branch "existing-remote-branch" was updated on remote
-    current_sha="$(git rev-parse --verify --short existing-remote-branch)"
+    current_sha="$(git rev-parse --verify --short ${FAKE_DEFAULT_BRANCH})"
     remote_sha="$(git rev-parse --verify --short origin/existing-remote-branch)"
 
     assert_equal $current_sha $remote_sha
@@ -749,7 +748,7 @@ cat_github_output() {
     assert_line -e "commit_hash=[0-9a-f]{40}$"
 }
 
-@test "script fails if new local branch is checked out and push fails as remote has newer commits than local" {
+@test "It fails if local branch is behind remote and when remote has newer commits" {
     # Create `existing-remote-branch` on remote with changes the local repository does not yet have
     cd $FAKE_TEMP_LOCAL_REPOSITORY
     git checkout -b "existing-remote-branch"
@@ -766,7 +765,6 @@ cat_github_output() {
     cd $FAKE_LOCAL_REPOSITORY
 
     INPUT_BRANCH="existing-remote-branch"
-    INPUT_CREATE_BRANCH=true
 
     run git branch
     refute_line --partial "existing-remote-branch"
@@ -781,17 +779,18 @@ cat_github_output() {
 
     assert_failure
 
-    assert_line "hint: Updates were rejected because the tip of your current branch is behind"
+    assert_line "hint: Updates were rejected because a pushed branch tip is behind its remote"
 
     # Assert that branch exists locally and on remote
     run git branch
-    assert_line --partial "existing-remote-branch"
+    assert_line --partial ${FAKE_DEFAULT_BRANCH}
+    refute_line --partial "existing-remote-branch"
 
     run git branch -r
     assert_line --partial "origin/existing-remote-branch"
 
     # Assert that branch "existing-remote-branch" was not updated on remote
-    current_sha="$(git rev-parse --verify --short existing-remote-branch)"
+    current_sha="$(git rev-parse --verify --short ${FAKE_DEFAULT_BRANCH})"
     remote_sha="$(git rev-parse --verify --short origin/existing-remote-branch)"
 
     refute [assert_equal $current_sha $remote_sha]


### PR DESCRIPTION
> [!Note]
> For folks browsing the repository and finding this PR: I've not yet merged this PR, as I haven't yet decided when and how to launch v6 of this action yet. 

This pull request tackles a long standing issue with this action: how the action works with branches internally. 

Since forever, the action will switch branches locally, if a branch name is provided through the `branch`-option.
This leads to a slew of problems, when users write workflows, where the repo is checked out using the default branch (`main`) but the changes are then pushed to a different branch (`example-branch-1`) (Example: https://github.com/stefanzweifel/git-auto-commit-action/discussions/301).

This annoyed me for a long time. There's no need to check out the given branch locally. A local branch does not have to align with the remote branch in order to push a commit to said remote branch.
We can target the right target branch in the `git-push` command.

---

This PR changes this behaviour by removing the `_switch_to_branch` function completely. 
By removing the function, the action also no longer runs `git-fetch`.

The test suite of the action has been adjusted accordingly. Some tests have been removed. Some tests have been rewritten, as removing the `_switch_to_branch` function changed the behaviour of the action in certain cases. See "Breaking Changes" section for details.

As this is a breaking change, this change will be released in an upcoming major release (v6) of this Action.

---

Why I added the current behaviour of switching branches locally is a mistery to me. I probably wrote the code this way, as I personally always mirror the branch names in my local repository with my remote repository. (I would work on a branch called `feature-x` and push that to `origin/feature-x` and not `origin/development`)

## Potential Issues

If a user checks out a repository on it's default branch (`main`), makes changes to the repo and pushes the changes to remote branch `example` which already exists on remote and has newer commits, the action will fail to push to remote with an error message like this:

```
Updates were rejected because the remote contains work that you do
not have locally. This is usually caused by another repository pushing
to the same ref. You may want to first integrate the remote changes
(e.g., 'git pull ...') before pushing again.
```

The solution here will still be, that the user has to solve these "out-of-sync" issues on their own by adding a `git-pull` or `git-rebase` step in their workflows.

## Breaking Changes

The following options have been removed from git-auto-commit and can be removed from your workflows.

- `create_branch` (git-auto-commit no longer switches branches locally during a workflow run)
- `skip_fetch`
- `skip_checkout`

## Related Issues

- #295 


## TODOs

- [x] Make tests green again
- [x] Write `UPGRADE.md`
- [x] Document breaking changes
- [x] Update Docs