### PR TITLE
Clarify `commit_author` input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ If you would like to use this Action to create a commit using [`--amend`](https:
 First, you need to extract the previous commit message by using `git log -1 --pretty=%s`.
 Then you need to provide this last commit message to the Action through the `commit_message` input option.
 
-By default, the commit author is changed to `username <username@users.noreply.github.com>`, where `username` is the name of the user who triggered the workflow (`github.actor`). If you want to preserve the name and email of the original author, you must extract them from the last commit and provide them to the Action through the `commit_author` input option.
+By default, the commit author is changed to `username <username@users.noreply.github.com>`, where `username` is the name of the user who triggered the workflow (The [`github.actor`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) context is used here). If you want to preserve the name and email of the original author, you must extract them from the last commit and provide them to the Action through the `commit_author` input option.
 
 Finally, you have to use `push_options: '--force'` to overwrite the git history on the GitHub remote repository. (git-auto-commit will not do a `git-rebase` for you!)
 


### PR DESCRIPTION
> This section only shows `Author <actions@github.com>` as an example and never states that the default commit author will be `username <username@users.noreply.github.com>`. I find this a bit misleading, maybe we should add an actual email address somewhere in the description?

As [discussed](https://github.com/stefanzweifel/git-auto-commit-action/issues/123#issuecomment-1868371506) in #123, clarified the default behavior of `commit_author` input option and extended the example to include guidance on preserving the original commit author.

```yaml
- name: Get last commit message
  id: last-commit
  run: |
    echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
    echo "author=$(git log -1 --pretty=\"%an <%ae>\")" >> $GITHUB_OUTPUT  # Optional: if you want to preserve the commit author

- uses: stefanzweifel/git-auto-commit-action@vN
  with:
    commit_author: ${{ steps.last-commit.outputs.author }}
    commit_message: ${{ steps.last-commit.outputs.message }}
    commit_options: '--amend --no-edit'
    push_options: '--force'
    skip_fetch: true
```

Feel free to point out potential changes or improvements)