### PR TITLE
Linux is not UNIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 ```
 
 > [!NOTE]
-> The Action has to be used in a Job that runs on a UNIX system (e.g. `ubuntu-latest`).
+> The Action has to be used in a Job that runs on a UNIX-like system (e.g. `ubuntu-latest`).
 
 The following is an extended example with all available options.
 


### PR DESCRIPTION
Excuse the pedantry, but Linux is not UNIX or even "a" UNIX.  UNIX is the trade-name for a specific operating system.  Although there are forks and therefore multiple UNIX's, Linux isn't a fork.  It was a completely separate OS from the ground up that happened to use UNIX as the template for what an OS should look like.  They've maintained compatibility via POSIX and more generally just attempting to harmonise their API.

Terms: "unix-like", "*nix", and possibly "POSIX" would be fine.  But naming Linux as UNIX is incorrect.