### PR TITLE
Include `github.actor_id` in default `commit_author`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
   commit_author:
     description: Value used for the commit author. Defaults to the username of whoever triggered this workflow run.
     required: false
-    default: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+    default: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
   tagging_message:
     description: Message used to create a new git tag with the commit. Keep this empty, if no tag should be created.
     required: false


### PR DESCRIPTION
This mimics the default commit author used by GitHub and matches the format used for the default `commit_user_email`.

**Motivation:** When I use the default settings, I end up with two different email addresses for the same commit author. By using the same default as GitHub, the author information remains consistent.