### PR TITLE
feat: allow for clean tag pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The following is an extended example with all available options.
 ```yaml
 - uses: stefanzweifel/git-auto-commit-action@v5
   with:
+    # Perform a clean git tag and push, without commiting anything
+    # Default to false
+    git_tag_only: false
+
     # Optional. Commit message for the created commit.
     # Defaults to "Apply automatic changes"
     commit_message: Automated Change

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ description: 'Automatically commits files which have been changed during the wor
 author: Stefan Zweifel <stefan@stefanzweifel.dev>
 
 inputs:
+  git_tag_only:
+    description: Perform a clean git tag and push, without commiting anything
+    required: false
+    default: false
   commit_message:
     description: Commit message
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ _main() {
     _check_if_git_is_available
 
     _switch_to_repository
-    if _git_tag_only; then
+    if "$INPUT_GIT_TAG_ONLY"; then
         _log "debug" "git tag only.";
         _set_github_output "git_tag_only" "true"
         _tag_commit

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,8 +30,12 @@ _main() {
     _check_if_git_is_available
 
     _switch_to_repository
-
-    if _git_is_dirty || "$INPUT_SKIP_DIRTY_CHECK"; then
+    if _git_tag_only; then
+        _log "debug" "git tag only.";
+        _set_github_output "git_tag_only" "true"
+        _tag_commit
+        _push_to_github
+    elif _git_is_dirty || "$INPUT_SKIP_DIRTY_CHECK"; then
 
         _set_github_output "changes_detected" "true"
 

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -21,6 +21,7 @@ setup() {
     export FAKE_DEFAULT_BRANCH=$(git config init.defaultBranch)
 
     # Set default INPUT variables used by the GitHub Action
+    export INPUT_GIT_TAG_ONLY=true
     export INPUT_REPOSITORY="${FAKE_LOCAL_REPOSITORY}"
     export INPUT_COMMIT_MESSAGE="Commit Message"
     export INPUT_BRANCH="${FAKE_DEFAULT_BRANCH}"

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -21,7 +21,7 @@ setup() {
     export FAKE_DEFAULT_BRANCH=$(git config init.defaultBranch)
 
     # Set default INPUT variables used by the GitHub Action
-    export INPUT_GIT_TAG_ONLY=true
+    export INPUT_GIT_TAG_ONLY=false
     export INPUT_REPOSITORY="${FAKE_LOCAL_REPOSITORY}"
     export INPUT_COMMIT_MESSAGE="Commit Message"
     export INPUT_BRANCH="${FAKE_DEFAULT_BRANCH}"


### PR DESCRIPTION
This PR contains the code change to allow this action to be invoked for performing a clean tag & push.
By clean I mean to commits are added, and no file changes are staged.
It is meant to be used in CD systems, where we wish to alter the tag, without allowing automation entities to modify the source code (anti-pattern). This action can now be used a the de-facto standard for perform git operations in a pipeline / automations.