### PR TITLE
Fix PAT instructions with Dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,11 @@ If you create a fine-grained personal access token, apply the `Contents`-permiss
 ```yaml
 - uses: actions/checkout@v4
   with:
-    token: ${{ secrets.PAT }}
+    token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 ```
 You can learn more about Personal Access Token in the [GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+
+Having a fallback to GITHUB_TOKEN helps things like Dependabot to continue working, as they may not be granted access to the PAT.
 
 > [!TIP] 
 > If you're working in an organisation, and you don't want to create the PAT from your personal account, we recommend using a bot-account for such tokens.

--- a/README.md
+++ b/README.md
@@ -461,11 +461,11 @@ If you create a fine-grained personal access token, apply the `Contents`-permiss
 ```yaml
 - uses: actions/checkout@v4
   with:
+    # We pass the "PAT" secret to the checkout action; if no PAT secret is available to the workflow runner (eg. Dependabot) we fall back to the default "GITHUB_TOKEN".
     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 ```
 You can learn more about Personal Access Token in the [GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
 
-Having a fallback to GITHUB_TOKEN helps things like Dependabot to continue working, as they may not be granted access to the PAT.
 
 > [!TIP] 
 > If you're working in an organisation, and you don't want to create the PAT from your personal account, we recommend using a bot-account for such tokens.


### PR DESCRIPTION
When following the instructions here, we always get this error in Dependabot PRs:
```
Error: Input required and not supplied: token
```

Adding a fallback to GITHUB_TOKEN seems to work fine.