### PR TITLE
Disable Check if Repo is in Detached State

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ _main() {
 
     _check_if_is_git_repository
 
-    _check_if_repository_is_in_detached_state
+    # _check_if_repository_is_in_detached_state
 
     if "$INPUT_CREATE_GIT_TAG_ONLY"; then
         _log "debug" "Create git tag only";

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -1098,6 +1098,7 @@ END
 }
 
 @test "It detects if the repository is in a detached state and exits with an error" {
+    skip
     touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
 
     run git_auto_commit


### PR DESCRIPTION
Disables the `_check_if_repository_is_in_detached_state` function that has been introduced in #357.
We will have to do further research on how to implement this or to scrap altogether.

Fixes #378.