### PR TITLE
[v7] Restore skip_fetch, skip_checkout, create_branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,18 @@ The following is an extended example with all available options.
     # Optional. Disable dirty check and always try to create a commit and push
     skip_dirty_check: true    
 
+    # Optional. Skip internal call to `git fetch`
+    skip_fetch: true
+
+    # Optional. Skip internal call to `git checkout`
+    skip_checkout: true
+
     # Optional. Prevents the shell from expanding filenames. 
     # Details: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
     disable_globbing: true
+
+    # Optional. Create given branch name in local and remote repository.
+    create_branch: true
 
     # Optional. Creates a new tag and pushes it to remote without creating a commit. 
     # Skips dirty check and changed files. Must be used with `tagging_message`.
@@ -412,6 +421,7 @@ The steps in your workflow might look like this:
     commit_message: ${{ steps.last-commit.outputs.message }}
     commit_options: '--amend --no-edit'
     push_options: '--force'
+    skip_fetch: true
 ```
 
 See discussion in [#159](https://github.com/stefanzweifel/git-auto-commit-action/issues/159#issuecomment-845347950) for details.

--- a/action.yml
+++ b/action.yml
@@ -56,8 +56,19 @@ inputs:
     description: Skip the check if the git repository is dirty and always try to create a commit.
     required: false
     default: false
+  skip_fetch:
+    description: Skip the call to git-fetch.
+    required: false
+    default: false
+  skip_checkout:
+    description: Skip the call to git-checkout.
+    required: false
+    default: false
   disable_globbing:
     description: Stop the shell from expanding filenames (https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html)
+    default: false
+  create_branch:
+    description: Create new branch with the name of `branch`-input in local and remote repository, if it doesn't exist yet.
     default: false
   create_git_tag_only:
     description: Perform a clean git tag and push, without commiting anything
@@ -66,17 +77,6 @@ inputs:
   internal_git_binary:
     description: Internal use only! Path to git binary used to check if git is available. (Don't change this!)
     default: git
-  skip_fetch:
-    description: "Deprecated: skip_fetch has been removed in v6. It does not have any effect anymore."
-    required: false
-    default: false
-  skip_checkout:
-    description: "Deprecated: skip_checkout has been removed in v6. It does not have any effect anymore."
-    required: false
-    default: false
-  create_branch:
-    description: "Deprecated: create_branch has been removed in v6. It does not have any effect anymore."
-    default: false
 
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ outputs:
     description: Value is "true", if a git tag was created using the `create_git_tag_only`-input.
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
 
 branding:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,18 +27,6 @@ _log() {
 }
 
 _main() {
-    if "$INPUT_SKIP_FETCH"; then
-        _log "warning" "git-auto-commit: skip_fetch has been removed in v6. It does not have any effect anymore.";
-    fi
-
-    if "$INPUT_SKIP_CHECKOUT"; then
-        _log "warning" "git-auto-commit: skip_checkout has been removed in v6. It does not have any effect anymore.";
-    fi
-
-    if "$INPUT_CREATE_BRANCH"; then
-        _log "warning" "git-auto-commit: create_branch has been removed in v6. It does not have any effect anymore.";
-    fi
-
     _check_if_git_is_available
 
     _switch_to_repository

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,8 @@ _main() {
 
         _set_github_output "changes_detected" "true"
 
+        _switch_to_branch
+
         _add_files
 
         # Check dirty state of repo again using git-diff.
@@ -124,6 +126,32 @@ _check_if_repository_is_in_detached_state() {
         exit 1;
     else
         _log "debug" "Repository is on a branch.";
+    fi
+}
+
+_switch_to_branch() {
+    echo "INPUT_BRANCH value: $INPUT_BRANCH";
+
+    # Fetch remote to make sure that repo can be switched to the right branch.
+    if "$INPUT_SKIP_FETCH"; then
+        _log "debug" "git-fetch will not be executed.";
+    else
+        git fetch --depth=1;
+    fi
+
+    # If `skip_checkout`-input is true, skip the entire checkout step.
+    if "$INPUT_SKIP_CHECKOUT"; then
+        _log "debug" "git-checkout will not be executed.";
+    else
+        # Create new local branch if `create_branch`-input is true
+        if "$INPUT_CREATE_BRANCH"; then
+            # shellcheck disable=SC2086
+            git checkout -B $INPUT_BRANCH --;
+        else
+            # Switch to branch from current Workflow run
+            # shellcheck disable=SC2086
+            git checkout $INPUT_BRANCH --;
+        fi
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ _main() {
 
     _check_if_is_git_repository
 
-    # _check_if_repository_is_in_detached_state
+    _check_if_repository_is_in_detached_state
 
     if "$INPUT_CREATE_GIT_TAG_ONLY"; then
         _log "debug" "Create git tag only";
@@ -110,8 +110,7 @@ _check_if_is_git_repository() {
 _check_if_repository_is_in_detached_state() {
     if [ -z "$(git symbolic-ref HEAD)" ]
     then
-        _log "error" "Repository is in detached HEAD state. Please make sure you check out a branch. Adjust the `ref` input accordingly.";
-        exit 1;
+        _log "warning" "Repository is in a detached HEAD state. git-auto-commit will likely handle this automatically. To avoid it, check out a branch using the ref option in actions/checkout.";
     else
         _log "debug" "Repository is on a branch.";
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,6 +124,7 @@ _switch_to_branch() {
     if "$INPUT_SKIP_FETCH"; then
         _log "debug" "git-fetch will not be executed.";
     else
+        _log "debug" "git-fetch will be executed.";
         git fetch --depth=1;
     fi
 
@@ -131,6 +132,7 @@ _switch_to_branch() {
     if "$INPUT_SKIP_CHECKOUT"; then
         _log "debug" "git-checkout will not be executed.";
     else
+        _log "debug" "git-checkout will be executed.";
         # Create new local branch if `create_branch`-input is true
         if "$INPUT_CREATE_BRANCH"; then
             # shellcheck disable=SC2086

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -1087,8 +1087,7 @@ END
     assert_line "::error::Not a git repository. Please make sure to run this action in a git repository. Adjust the `repository` input if necessary."
 }
 
-@test "It detects if the repository is in a detached state and exits with an error" {
-    skip
+@test "It detects if the repository is in a detached state and logs a warning" {
     touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
 
     run git_auto_commit
@@ -1103,8 +1102,8 @@ END
 
     run git_auto_commit
 
-    assert_failure;
-    assert_line "::error::Repository is in detached HEAD state. Please make sure you check out a branch. Adjust the `ref` input accordingly."
+    assert_success;
+    assert_line "::warning::Repository is in a detached HEAD state. git-auto-commit will likely handle this automatically. To avoid it, check out a branch using the ref option in actions/checkout."
 }
 
 @test "it creates a tag if create_git_tag_only is set to true and a message has been supplied" {


### PR DESCRIPTION
This PR reverts the changes introduces in #314 and restores `skip_fetch`, `skip_checkout` and `create_branch`.

## Why a revert?

#383 and #385 have shown to me, that I've rushed the changes out too soon and that the `git-fetch` and `git-checkout` call have important purpose in the project.

I will probabl don't make another attempt of removing them again.

## Fixes

- #385 
- #383 