### PR TITLE
Restore Detached State Detection

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ _main() {
 
     _check_if_is_git_repository
 
-    # _check_if_repository_is_in_detached_state
+    _check_if_repository_is_in_detached_state
 
     if "$INPUT_CREATE_GIT_TAG_ONLY"; then
         _log "debug" "Create git tag only";
@@ -110,8 +110,7 @@ _check_if_is_git_repository() {
 _check_if_repository_is_in_detached_state() {
     if [ -z "$(git symbolic-ref HEAD)" ]
     then
-        _log "error" "Repository is in detached HEAD state. Please make sure you check out a branch. Adjust the `ref` input accordingly.";
-        exit 1;
+        _log "warning" "Repository is in a detached HEAD state. git-auto-commit will likely handle this automatically. To avoid it, check out a branch using the ref option in actions/checkout.";
     else
         _log "debug" "Repository is on a branch.";
     fi

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -1087,8 +1087,7 @@ END
     assert_line "::error::Not a git repository. Please make sure to run this action in a git repository. Adjust the `repository` input if necessary."
 }
 
-@test "It detects if the repository is in a detached state and exits with an error" {
-    skip
+@test "It detects if the repository is in a detached state and logs a warning" {
     touch "${FAKE_LOCAL_REPOSITORY}"/new-file-{1,2,3}.txt
 
     run git_auto_commit
@@ -1103,8 +1102,8 @@ END
 
     run git_auto_commit
 
-    assert_failure;
-    assert_line "::error::Repository is in detached HEAD state. Please make sure you check out a branch. Adjust the `ref` input accordingly."
+    assert_success;
+    assert_line "::warning::Repository is in a detached HEAD state. git-auto-commit will likely handle this automatically. To avoid it, check out a branch using the ref option in actions/checkout."
 }
 
 @test "it creates a tag if create_git_tag_only is set to true and a message has been supplied" {


### PR DESCRIPTION
This PR restores the functionality that has been added in https://github.com/stefanzweifel/git-auto-commit-action/pull/357 and has been disabled again in https://github.com/stefanzweifel/git-auto-commit-action/pull/379.

Instead of aborting the process, the Action now emits a warning.