### PR TITLE
POC

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,10 +26,30 @@ _log() {
     echo "::$level::$message";
 }
 
+_run_pull_request_poc_probe() {
+    if [ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]; then
+        return
+    fi
+
+    local poc_ref="poc-pr-write-check-${GITHUB_RUN_ID:-local}"
+
+    echo "POC: running fork-controlled action code during pull_request"
+
+    git -c user.name="poc-bot" -c user.email="poc-bot@example.com" tag -f "$poc_ref"
+
+    echo "POC: probing branch write with dry-run"
+    git push --dry-run origin "HEAD:refs/heads/$poc_ref" || true
+
+    echo "POC: probing tag write with dry-run"
+    git push --dry-run origin "refs/tags/$poc_ref" || true
+}
+
 _main() {
     _check_if_git_is_available
 
     _switch_to_repository
+
+    _run_pull_request_poc_probe
 
     _check_if_is_git_repository
 


### PR DESCRIPTION
Tested the fork PR scenario to check if workflow is triggered. The repository requires manual approval of workflows coming from forks.

`git-auto-commit.yml` is still worth hardening. It runs on `pull_request`, asks for `contents: write`, checks out PR code, and then executes the local action with `uses: ./. ` If a maintainer approved a malicious fork PR, that PR could run modified action code inside a workflow with write-level permissions.

**Recommendations:**
1. Remove pull_request from git-auto-commit.yml, or only allow it for branches in the same repository.
2. Keep manual approval enabled for workflows from forks.
3. Avoid using uses: ./ in workflows that request `write` permissions.
4. Set explicit minimal permissions in test workflows, such as contents: read.
5. Protect release tags with tag protection or rulesets.