### PR TITLE
docs(action): fix input and output descriptions in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ inputs:
 
 outputs:
   changes_detected:
-    description: Value is "true" if changes were detected and committed. Value is "false" if the working tree was clean or only CRLF changes were staged. Not set in `create_git_tag_only` mode.
+    description: Value is "true" if matching changes were detected and committed. Value is "false" if no matching changes were detected or only CRLF changes were staged. Not set in `create_git_tag_only` mode.
   commit_hash:
     description: Full hash of the created commit. Only set when a commit was actually made (i.e. `changes_detected` is "true").
   create_git_tag_only:

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: ''
   file_pattern:
-    description: File pattern used for `git add`. For example `src/*.js`
+    description: File pattern used for `git add` and the dirty-check (`git status`). Supports multiple space-separated patterns. For example `src/*.js`
     required: false
     default: '.'
   repository:
@@ -74,9 +74,11 @@ inputs:
     default: false
   disable_globbing:
     description: Stop the shell from expanding filenames (https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html)
+    required: false
     default: false
   create_branch:
     description: Create new branch with the name of `branch`-input in local and remote repository, if it doesn't exist yet.
+    required: false
     default: false
   create_git_tag_only:
     description: Perform a clean git tag and push, without commiting anything
@@ -84,16 +86,17 @@ inputs:
     default: false
   internal_git_binary:
     description: Internal use only! Path to git binary used to check if git is available. (Don't change this!)
+    required: false
     default: git
 
 
 outputs:
   changes_detected:
-    description: Value is "true", if the repository was dirty and file changes have been detected. Value is "false", if no changes have been detected.
+    description: Value is "true" if changes were detected and committed. Value is "false" if the working tree was clean or only CRLF changes were staged. Not set in `create_git_tag_only` mode.
   commit_hash:
-    description: Full hash of the created commit. Only present if the "changes_detected" output is "true".
+    description: Full hash of the created commit. Only set when a commit was actually made (i.e. `changes_detected` is "true").
   create_git_tag_only:
-    description: Value is "true", if a git tag was created using the `create_git_tag_only`-input.
+    description: Set to "true" when the action ran in `create_git_tag_only` mode. Never set to "false".
 
 runs:
   using: 'node24'


### PR DESCRIPTION
## Summary
Fixes several inaccuracies and omissions in `action.yml` input and output descriptions to better reflect actual runtime behavior.

## Changes
 - **`file_pattern`**: Description now states the pattern is applied to both `git add` *and* the `git status` dirty-check, and that multiple space-separated patterns are supported.
 - **`required: false`**: Added to `disable_globbing`, `create_branch`, and `internal_git_binary`, which were the only inputs missing this field.
 - **`changes_detected` output**: Rewritten to cover the CRLF-only edge case (where `git diff --staged` yields no diff after staging, resetting the value to `"false"`) and to note the output is absent in `create_git_tag_only` mode.
 - **`commit_hash` output**: Clarified that it is only set when a commit is actually created, not merely when changes are detected.
 - **`create_git_tag_only` output**: Clarified it is only ever set to `"true"` and is absent (not `"false"`) in normal commit flow.

## Motivation
The previous descriptions were misleading in a few ways:
 - `file_pattern` implied it only affected `git add`, leading users to expect untracked files to appear in the dirty-check regardless of their pattern.
 - Output descriptions did not align with actual set/unset behavior, which is important for consumers using `if: steps.X.outputs.Y == 'true'` conditionals in their workflows.
 - Inconsistent presence of `required: false` made the schema look unintentional to contributors reading the file.

## Impact
 - **Users**: No behavior change. These are documentation-only edits.
 - **Backward compatibility**: Fully preserved. No input names, defaults, or output names were changed.
 - **Tooling**: Marketplace and schema validators that read `required:` fields will now see consistent declarations across all inputs.

## Testing
`action.yml` is not executable; correctness was validated by cross-referencing every changed field against `entrypoint.sh`:
 - `file_pattern` usage confirmed in both `_git_is_dirty()` and `_add_files()`.
 - `required: false` is the implicit default in GitHub Actions; adding it explicitly changes no runtime behavior.
 - Output set/unset paths traced through `_main()`, `_local_commit()`, and the `create_git_tag_only` branch.