### PR TITLE
Emit warning for pull_request_target trigger usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ The following is an extended example with all available options.
     # Optional. Creates a new tag and pushes it to remote without creating a commit.
     # Skips dirty check and changed files. Must be used in combination with `tag` and `tagging_message`.
     create_git_tag_only: false
+
+    # Optional. Suppress the security warning emitted when the action runs on a
+    # `pull_request_target` event. See the "Workflow should run in **base** repository"
+    # section below for context before disabling this warning.
+    disable_pull_request_target_trigger_warning: false
 ```
 
 Please note that the Action depends on `bash`. If you're using the Action in a job in combination with a custom Docker container, make sure that `bash` is installed.

--- a/README.md
+++ b/README.md
@@ -356,10 +356,13 @@ However, there are a couple of ways to use this Action in Workflows that should 
 > [!CAUTION]
 > The following section explains how you can use git-auto-commit in combination with the `pull_request_target` trigger.
 > **Using `pull_request_target` in your workflows can lead to repository compromise as [mentioned](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) by GitHub's own security team. This means, that a bad actor could potentially leak/steal your GitHub Actions repository secrets.**
-> Please be aware of this risk when using `pull_request_target` in your workflows.
+> Please be aware of this risk when using `pull_request_target` in your workflows. See [GitHub's documentation](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target) for more information.
 >
 > If your workflow runs code-fixing tools, consider running the workflow on your default branch by listening to the `push` event or use a third-party tool like [autofix.ci](https://autofix.ci/).
 > We keep this documentation around, as many questions came in over the years, on how to use this action for public forks.
+>
+> To remind users of this risk, git-auto-commit emits a warning annotation whenever it detects it is running on a `pull_request_target` event.
+> If you have evaluated the risk and want to silence the warning, set the `disable_pull_request_target_trigger_warning` input to `true`.
 
 The workflow below runs whenever a commit is pushed to the `main`-branch or when activity on a pull request happens, by listening to the [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event.
 

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,10 @@ inputs:
     description: Perform a clean git tag and push, without commiting anything
     required: false
     default: false
+  disable_pull_request_target_trigger_warning:
+    description: Suppress the security warning emitted when the action runs on a `pull_request_target` event.
+    required: false
+    default: false
   internal_git_binary:
     description: Internal use only! Path to git binary used to check if git is available. (Don't change this!)
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,8 @@ _main() {
 
     _check_if_repository_is_in_detached_state
 
+    _check_for_pull_request_target_trigger
+
     if "$INPUT_CREATE_GIT_TAG_ONLY"; then
         _log "debug" "Create git tag only";
         _set_github_output "create_git_tag_only" "true"
@@ -104,6 +106,16 @@ _check_if_is_git_repository() {
     else
         _log "error" "Not a git repository. Please make sure to run this action in a git repository. Adjust the `repository` input if necessary.";
         exit 1;
+    fi
+}
+
+_check_for_pull_request_target_trigger() {
+    if "$INPUT_DISABLE_PULL_REQUEST_TARGET_TRIGGER_WARNING"; then
+        return
+    fi
+
+    if [ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ]; then
+        _log "warning" "git-auto-commit is running on a 'pull_request_target' event. This trigger can be a security risk: a malicious pull request could potentially exfiltrate your repository secrets. See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target and the 'pull_request_target' section in the git-auto-commit README (https://github.com/stefanzweifel/git-auto-commit-action#using-the-action-in-a-pull_request_target-workflow) for safer usage. Set 'disable_pull_request_target_trigger_warning: true' to suppress this warning.";
     fi
 }
 

--- a/tests/git-auto-commit.bats
+++ b/tests/git-auto-commit.bats
@@ -41,7 +41,12 @@ setup() {
     export INPUT_SKIP_PUSH=false
     export INPUT_DISABLE_GLOBBING=false
     export INPUT_CREATE_BRANCH=false
+    export INPUT_DISABLE_PULL_REQUEST_TARGET_TRIGGER_WARNING=false
     export INPUT_INTERNAL_GIT_BINARY=git
+
+    # Unset the GitHub event name by default so tests do not pick up
+    # pull_request_target from the environment of the shell running BATS.
+    unset GITHUB_EVENT_NAME
 
     # Set GitHub environment variables used by the GitHub Action
     temp_github_output_file=$(mktemp -t github_output_test.XXXXX)
@@ -1520,4 +1525,50 @@ END
     remote_sha="$(git rev-parse --verify --short origin/${FAKE_DEFAULT_BRANCH})"
 
     assert_equal $current_sha $remote_sha
+}
+
+@test "It emits a warning when running on a pull_request_target event" {
+    export GITHUB_EVENT_NAME="pull_request_target"
+
+    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-1.txt
+
+    run git_auto_commit
+
+    assert_success
+    assert_output --partial "::warning::git-auto-commit is running on a 'pull_request_target' event."
+    assert_output --partial "disable_pull_request_target_trigger_warning"
+}
+
+@test "It does not emit the pull_request_target warning when the event is pull_request" {
+    export GITHUB_EVENT_NAME="pull_request"
+
+    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-1.txt
+
+    run git_auto_commit
+
+    assert_success
+    refute_output --partial "::warning::git-auto-commit is running on a 'pull_request_target' event."
+}
+
+@test "It does not emit the pull_request_target warning when GITHUB_EVENT_NAME is unset" {
+    unset GITHUB_EVENT_NAME
+
+    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-1.txt
+
+    run git_auto_commit
+
+    assert_success
+    refute_output --partial "::warning::git-auto-commit is running on a 'pull_request_target' event."
+}
+
+@test "It does not emit the pull_request_target warning when disable_pull_request_target_trigger_warning is true" {
+    export GITHUB_EVENT_NAME="pull_request_target"
+    export INPUT_DISABLE_PULL_REQUEST_TARGET_TRIGGER_WARNING=true
+
+    touch "${FAKE_LOCAL_REPOSITORY}"/new-file-1.txt
+
+    run git_auto_commit
+
+    assert_success
+    refute_output --partial "::warning::git-auto-commit is running on a 'pull_request_target' event."
 }


### PR DESCRIPTION
This pull request adds a new security warning to alert users when the action is triggered by a `pull_request_target` event, which can expose repository secrets. It also introduces an input to suppress this warning if desired, updates documentation to clarify the risks, and adds tests to verify the new behavior.